### PR TITLE
Nixpkgs 23.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,22 +960,22 @@
         "nix": "nix_5",
         "nixpkgs": "nixpkgs_34",
         "nixpkgs-unstable": "nixpkgs-unstable_5",
+        "opentofu-registry": "opentofu-registry",
         "sops-nix": "sops-nix",
-        "terraform-providers": "terraform-providers",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1701717124,
-        "narHash": "sha256-zvbbwzE8rccUGVbCn8qSrK5DHTETsMH0kWfRu2ZQrrc=",
+        "lastModified": 1701903945,
+        "narHash": "sha256-QHwJwUiNHY9f9jxCqj6eavQYZgzJckFSzPfsqNJdnMM=",
         "owner": "input-output-hk",
         "repo": "cardano-parts",
-        "rev": "6f91a19785428408c0eaaef953a071f891dbb6c5",
+        "rev": "07fd1dbff9a196c25b9da0bdf7218be468ea699f",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "sancho-respin",
+        "ref": "nixpkgs-23-11",
         "repo": "cardano-parts",
         "type": "github"
       }
@@ -2040,24 +2040,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_5": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_5"
-      },
-      "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
         "type": "github"
       },
       "original": {
@@ -3277,16 +3259,15 @@
         "sodium": "sodium_5"
       },
       "locked": {
-        "lastModified": 1701180836,
+        "lastModified": 1701223254,
         "narHash": "sha256-k02Q+vuYHETqDMfnC4ORpHNKWUDpVWTeiETCmf7+gBA=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "d8dae0b5558db304e4a69b7eb31e2e0bd4790379",
+        "rev": "ac6932d5f18c6f249a392fe4edbc2ca15257a512",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "sancho-respin-2023-11-28",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -3973,16 +3954,16 @@
         "nixpkgs-regression": "nixpkgs-regression_5"
       },
       "locked": {
-        "lastModified": 1693573010,
-        "narHash": "sha256-HBm8mR2skhPtbJ7p+ByrOZjs7SfsfZPwy75MwI1EUmk=",
+        "lastModified": 1701705406,
+        "narHash": "sha256-c7/VJH/3/NdmJQe3X7Hlf/tFQ265n2hXGWA+0conEO8=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "5568ca5ff130a8a0bc3db5878432eb527c74dd60",
+        "rev": "aaeab0040126d7e0bf59886abd4a1e2855482ee9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "2.17-maintenance",
+        "ref": "2.19-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -4616,24 +4597,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_5": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -4796,27 +4759,11 @@
     },
     "nixpkgs-unstable_5": {
       "locked": {
-        "lastModified": 1696577711,
-        "narHash": "sha256-94VRjvClIKDym1QRqPkX5LTQoAwZ1E6QE/3dWtOXSIQ=",
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2eb207f45e4a14a1e3019d9e3863d1e208e2295",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_6": {
-      "locked": {
-        "lastModified": 1689844446,
-        "narHash": "sha256-ud/6XYWbXFAJuTTApWyYlFtlc54NAxChS1T9Ns+qT7M=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2d82894fa1e2d23a22f40275a78bfbb09b92ffde",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {
@@ -5218,32 +5165,32 @@
     },
     "nixpkgs_33": {
       "locked": {
-        "lastModified": 1670461440,
-        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
+        "lastModified": 1700748986,
+        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11-small",
+        "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_34": {
       "locked": {
-        "lastModified": 1691328192,
-        "narHash": "sha256-w59N1zyDQ7SupfMJLFvtms/SIVbdryqlw5AS4+DiH+Y=",
+        "lastModified": 1701539137,
+        "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61676e4dcfeeb058f255294bcb08ea7f3bc3ce56",
+        "rev": "933d7dc155096e7575d207be6fb7792bc9f34f6d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5266,22 +5213,6 @@
     },
     "nixpkgs_36": {
       "locked": {
-        "lastModified": 1675249806,
-        "narHash": "sha256-u8Rcqekusl3pMZm68hZqr6zozI8Ug5IxqOiqDLAlu1k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "79feedf38536de2a27d13fe2eaf200a9c05193ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_37": {
-      "locked": {
         "lastModified": 1636823747,
         "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
         "owner": "nixos",
@@ -5291,22 +5222,6 @@
       },
       "original": {
         "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_38": {
-      "locked": {
-        "lastModified": 1685865905,
-        "narHash": "sha256-XJZ/o17eOd2sEsGif+/MQBnfa2DKmndWgJyc7CWajFc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e7603eba51f2c7820c0a182c6bbb351181caa8e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5545,6 +5460,22 @@
         "owner": "angerman",
         "ref": "master",
         "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "opentofu-registry": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701811617,
+        "narHash": "sha256-0RcmJU6qkldb3VOEM37PG02D25LNaA12Oy794dr1Ih8=",
+        "owner": "opentofu",
+        "repo": "registry",
+        "rev": "3d8c146c42fccfcfe89d81a46cd4268bd39aa242",
+        "type": "github"
+      },
+      "original": {
+        "owner": "opentofu",
+        "repo": "registry",
         "type": "github"
       }
     },
@@ -5942,9 +5873,18 @@
         "cardano-node-821-pre": "cardano-node-821-pre",
         "cardano-node-hd": "cardano-node-hd",
         "cardano-parts": "cardano-parts",
-        "flake-parts": "flake-parts_5",
-        "nixpkgs": "nixpkgs_38",
-        "nixpkgs-unstable": "nixpkgs-unstable_6"
+        "flake-parts": [
+          "cardano-parts",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "cardano-parts",
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": [
+          "cardano-parts",
+          "nixpkgs-unstable"
+        ]
       }
     },
     "rust-analyzer-src": {
@@ -6610,30 +6550,12 @@
         "type": "github"
       }
     },
-    "terraform-providers": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_36"
-      },
-      "locked": {
-        "lastModified": 1695893013,
-        "narHash": "sha256-+5EuXNXwxpTiOEGCbZWtZCU75WcVwnS89heLa5xJ2K0=",
-        "owner": "nix-community",
-        "repo": "nixpkgs-terraform-providers-bin",
-        "rev": "6c6865ae6f9bff7aaa4e86c875f520f2aca65c0d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs-terraform-providers-bin",
-        "type": "github"
-      }
-    },
     "terranix": {
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_22",
-        "nixpkgs": "nixpkgs_37",
+        "nixpkgs": "nixpkgs_36",
         "terranix-examples": "terranix-examples"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   description = "Cardano Playground: cardano testnet clusters";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    cardano-parts.url = "github:input-output-hk/cardano-parts/sancho-respin";
-    # cardano-parts.url = "path:/home/jlotoski/work/iohk/cardano-parts-wt/sancho-respin";
+    nixpkgs.follows = "cardano-parts/nixpkgs";
+    nixpkgs-unstable.follows = "cardano-parts/nixpkgs-unstable";
+    flake-parts.follows = "cardano-parts/flake-parts";
+    cardano-parts.url = "github:input-output-hk/cardano-parts/nixpkgs-23-11";
+    # cardano-parts.url = "path:/home/jlotoski/work/iohk/cardano-parts-wt/nixpkgs-23-11";
 
     # Local pins for additional customization:
     cardano-node.url = "github:input-output-hk/cardano-node/8.1.2";
@@ -47,6 +47,6 @@
   nixConfig = {
     extra-substituters = ["https://cache.iog.io"];
     extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
-    allow-import-from-derivation = "true";
+    allow-import-from-derivation = true;
   };
 }

--- a/flake/cluster.nix
+++ b/flake/cluster.nix
@@ -39,15 +39,17 @@ with flake.lib; {
             lib.cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg;
 
             # Until upstream parts ng has capkgs version, use local flake pins
-            pkgs.cardano-cli = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-cli-ng);
-            pkgs.cardano-db-sync = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-db-sync-ng);
-            pkgs.cardano-db-tool = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-db-tool-ng);
-            pkgs.cardano-db-sync-pkgs = flake.config.flake.cardano-parts.pkgs.special.cardano-db-sync-pkgs-ng;
-            pkgs.cardano-faucet = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-faucet-ng);
-            pkgs.cardano-node = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-node-ng);
-            pkgs.cardano-smash = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-smash-ng);
-            pkgs.cardano-submit-api = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-submit-api-ng);
-            pkgs.cardano-node-pkgs = flake.config.flake.cardano-parts.pkgs.special.cardano-node-pkgs-ng;
+            pkgs = {
+              cardano-cli = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-cli-ng);
+              cardano-db-sync = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-db-sync-ng);
+              cardano-db-tool = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-db-tool-ng);
+              cardano-db-sync-pkgs = flake.config.flake.cardano-parts.pkgs.special.cardano-db-sync-pkgs-ng;
+              cardano-faucet = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-faucet-ng);
+              cardano-node = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-node-ng);
+              cardano-smash = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-smash-ng);
+              cardano-submit-api = system: flake.withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-submit-api-ng);
+              cardano-node-pkgs = flake.config.flake.cardano-parts.pkgs.special.cardano-node-pkgs-ng;
+            };
           };
       };
     in

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -266,17 +266,17 @@ in {
     # Setup cardano-world networks:
     # ---------------------------------------------------------------------------------------------------------
     # Preprod, two-thirds on release tag, one-third on pre-release tag
-    preprod1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node bp];};
-    preprod1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node rel preprodRelMig];};
-    preprod1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod1") node rel preprodRelMig];};
-    preprod1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod1") node rel preprodRelMig];};
-    preprod1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preprod1") dbsync smash preprodSmash];};
+    preprod1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node bp pre];};
+    preprod1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+    preprod1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+    preprod1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+    preprod1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preprod1") dbsync smash pre preprodSmash];};
     preprod1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node faucet pre preprodFaucet];};
 
-    preprod2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node bp];};
-    preprod2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod2") node rel preprodRelMig];};
-    preprod2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node rel preprodRelMig];};
-    preprod2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod2") node rel preprodRelMig];};
+    preprod2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node bp pre];};
+    preprod2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
+    preprod2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
+    preprod2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
 
     preprod3-bp-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod3") node bp pre];};
     preprod3-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
@@ -286,11 +286,11 @@ in {
 
     # ---------------------------------------------------------------------------------------------------------
     # Preview, one-third on release tag, two-thirds on pre-release tag
-    preview1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node bp];};
-    preview1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node rel previewRelMig];};
-    preview1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview1") node rel previewRelMig];};
-    preview1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview1") node rel previewRelMig];};
-    preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preview1") dbsync smash previewSmash];};
+    preview1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node bp pre];};
+    preview1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+    preview1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+    preview1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+    preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preview1") dbsync smash pre previewSmash];};
     preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre previewFaucet];};
 
     preview2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview2") node bp pre];};
@@ -367,7 +367,7 @@ in {
 
     # ---------------------------------------------------------------------------------------------------------
     # Mainnet
-    mainnet1-dbsync-a-1 = {imports = [eu-central-1 r5-2xlarge (ebs 1000) (group "mainnet1") dbsync];};
+    mainnet1-dbsync-a-1 = {imports = [eu-central-1 r5-2xlarge (ebs 1000) (group "mainnet1") dbsync pre];};
     mainnet1-rel-a-1 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node ram8gib];};
     mainnet1-rel-a-2 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram5gibActual];};
     mainnet1-rel-a-3 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram8gib];};

--- a/flake/terraform/cluster.nix
+++ b/flake/terraform/cluster.nix
@@ -89,10 +89,10 @@ in {
       {
         terraform = {
           required_providers = {
-            aws.source = "hashicorp/aws";
-            null.source = "hashicorp/null";
-            local.source = "hashicorp/local";
-            tls.source = "hashicorp/tls";
+            aws.source = "opentofu/aws";
+            null.source = "opentofu/null";
+            local.source = "opentofu/local";
+            tls.source = "opentofu/tls";
           };
 
           backend = {
@@ -111,11 +111,11 @@ in {
         });
 
         # Common parameters:
-        #   data.aws_caller_identity.current.account_id
-        #   data.aws_region.current.name
-        data.aws_caller_identity.current = {};
-        data.aws_region.current = {};
-        data.aws_route53_zone.selected.name = "${cluster.domain}.";
+        data = {
+          aws_caller_identity.current = {};
+          aws_region.current = {};
+          aws_route53_zone.selected.name = "${cluster.domain}.";
+        };
 
         resource = {
           aws_instance = mapNodes (


### PR DESCRIPTION
# Overview
* Bumps nixpkgs to 23.11 release and nix to 2.19.3, adding required module config changes, lint updates and tofu utilization.

# Details
* Updates the flake to default to following cardano-parts for nixpkgs, nixpkgs-unstable and flake-parts pins
  * Bumps nixpkgs -> 23.11, nixpkgs-unstable -> HEAD, nix -> 2.19.3
* Migrates from terraform to opentofu to maintain open source license usage
  * The prior `just tf` and `just terraform` recipes remain as aliases to `just tofu`
  * The `terraform` binary no longer exists in the devShell and has been replaced by `tofu` binary
* Configure 8.7.1-pre for full preview, preprod clusters in prep for release