### PR TITLE
Voltaire swagger UI on private chain

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,6 +19,7 @@ keys:
 
   # Private
   - &private1-bp-a-1 age1pwmcf9nez82glwzk3mfcfyv0wnc4yev8pjhxk43fwgcr3m8yjsesjdfha0
+  - &private1-dbsync-a-1 age1q435aw99zpavtn5ce770jesh3th0ghne8jkt5mse8zscpp5r2ghsark64e
   - &private1-faucet-a-1 age1lack6chc6czx8t9sc9ayc3wq0du82ne6l8m5h6lwz8zn6rxz5gqqtpz4z2
   - &private2-bp-b-1 age1wewhhymvzljpgy7v9caud2zmgjt7dsdcluvpq8373ueuj5qv435qgn9xae
   - &private3-bp-c-1 age1ay9e566ksavc46809vzjzcwlsu06dzr869fdv8qf9p9qu69qva4ssdv4af
@@ -103,7 +104,13 @@ creation_rules:
       - *preview3-bp-c-1
 
   # Private specific
-  - path_regex: secrets/groups/private1/deploy/.*faucet.*$
+  - path_regex: secrets/groups/private1/deploy/.*vva-be.*$
+    key_groups:
+    - age:
+      - *sre
+      - *private1-dbsync-a-1
+
+  - path_regex: secrets/groups/private/deploy/.*faucet.*$
     key_groups:
     - age:
       - *sre

--- a/Justfile
+++ b/Justfile
@@ -610,6 +610,6 @@ tofu *ARGS:
   rm --force terraform.tf.json
   nix build ".#terraform.$WORKSPACE" --out-link terraform.tf.json
 
-  tofu workspace select -or-create "$WORKSPACE"
   tofu init -reconfigure
+  tofu workspace select -or-create "$WORKSPACE"
   tofu ${ARGS[@]} ${VAR_FILE:+-var-file=<("${SOPS[@]}" "$VAR_FILE")}

--- a/flake.lock
+++ b/flake.lock
@@ -159,16 +159,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1702939833,
-        "narHash": "sha256-1ay7Lo2tKRyV/DV8lsSraZvyCurr19FJtqaAkwGZ5zc=",
+        "lastModified": 1703018934,
+        "narHash": "sha256-7h6XsWczUzsxID0H5QX0+bJks22pijAxnSJ2RYTyswQ=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "2bc614b16d3bfd782563cb05c0e8331d0ebcb1a9",
+        "rev": "31f8d4e404bf64d559516abfd6610bb7f4cabee2",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "more-assertions",
         "repo": "auth-keys-hub",
         "type": "github"
       }
@@ -1167,11 +1166,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1702960071,
-        "narHash": "sha256-6PacmrjLnMFbc2Ox2rDO0sv80vy9y72TISwG7nv8w+Q=",
+        "lastModified": 1703117348,
+        "narHash": "sha256-s1QbyDrXy9sHQSTO5ij3zuALTNjRBMR/Q42+jc5lBow=",
         "owner": "input-output-hk",
         "repo": "cardano-parts",
-        "rev": "56b19d2f7d1583d89e38b8336531e2b009ad895b",
+        "rev": "05d05abb15ada3e96c697481662f15bc6b52d329",
         "type": "github"
       },
       "original": {
@@ -3043,6 +3042,27 @@
         "type": "github"
       }
     },
+    "govtool": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_44",
+        "nixpkgs-vva-be": "nixpkgs-vva-be"
+      },
+      "locked": {
+        "lastModified": 1703089856,
+        "narHash": "sha256-kdelYrmvSu61xYnpssE4rbako4XQWtXi3Mudl2UYQJE=",
+        "owner": "IntersectMBO",
+        "repo": "govtool",
+        "rev": "eef7a843e7ab6f70be9d3f0b567a2c87ae0200d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "flake",
+        "repo": "govtool",
+        "type": "github"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -4047,7 +4067,7 @@
     "iohk-nix-legacy": {
       "inputs": {
         "blst": "blst_7",
-        "nixpkgs": "nixpkgs_44",
+        "nixpkgs": "nixpkgs_45",
         "secp256k1": "secp256k1_7",
         "sodium": "sodium_7"
       },
@@ -6592,22 +6612,6 @@
     },
     "nixpkgs_44": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_45": {
-      "locked": {
         "lastModified": 1702682804,
         "narHash": "sha256-OmLBqssY08BqwSce2MpnGQxDpzQDMzPuZj8D0zFIKkg=",
         "owner": "nixos",
@@ -6618,6 +6622,22 @@
       "original": {
         "owner": "nixos",
         "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_45": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -7506,6 +7526,7 @@
           "cardano-parts",
           "flake-parts"
         ],
+        "govtool": "govtool",
         "iohk-nix-legacy": "iohk-nix-legacy",
         "nixpkgs": [
           "cardano-parts",
@@ -7514,8 +7535,7 @@
         "nixpkgs-unstable": [
           "cardano-parts",
           "nixpkgs-unstable"
-        ],
-        "vva": "vva"
+        ]
       }
     },
     "rust-analyzer-src": {
@@ -8675,27 +8695,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "vva": {
-      "inputs": {
-        "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_45",
-        "nixpkgs-vva-be": "nixpkgs-vva-be"
-      },
-      "locked": {
-        "lastModified": 1703028398,
-        "narHash": "sha256-xWyWam3HPImBCULNtFbb23kaKNVrqXx/TpcvMv5FiII=",
-        "owner": "input-output-hk",
-        "repo": "voltaire-era",
-        "rev": "ff31ddff251e4e817522f24f58a8e1e53ad6482d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "flake",
-        "repo": "voltaire-era",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -2403,6 +2403,24 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -5754,6 +5772,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -5959,6 +5995,22 @@
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-vva-be": {
+      "locked": {
+        "lastModified": 1679410443,
+        "narHash": "sha256-xDHO/jixWD+y5pmW5+2q4Z4O/I/nA4MAa30svnZKK+M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
         "type": "github"
       }
     },
@@ -6550,6 +6602,22 @@
       "original": {
         "owner": "nixos",
         "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_45": {
+      "locked": {
+        "lastModified": 1702682804,
+        "narHash": "sha256-OmLBqssY08BqwSce2MpnGQxDpzQDMzPuZj8D0zFIKkg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6ddf6a21fb3d30a6cc808c5c4e68318bfaa2cbc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -7446,7 +7514,8 @@
         "nixpkgs-unstable": [
           "cardano-parts",
           "nixpkgs-unstable"
-        ]
+        ],
+        "vva": "vva"
       }
     },
     "rust-analyzer-src": {
@@ -8606,6 +8675,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "vva": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_45",
+        "nixpkgs-vva-be": "nixpkgs-vva-be"
+      },
+      "locked": {
+        "lastModified": 1703028398,
+        "narHash": "sha256-xWyWam3HPImBCULNtFbb23kaKNVrqXx/TpcvMv5FiII=",
+        "owner": "input-output-hk",
+        "repo": "voltaire-era",
+        "rev": "ff31ddff251e4e817522f24f58a8e1e53ad6482d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "flake",
+        "repo": "voltaire-era",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -126,15 +126,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1702655420,
-        "narHash": "sha256-w1gxNRrzMsHIAb73ofjrYlVv/4sR+SF3Q/NA+nXCDOc=",
+        "lastModified": 1702939833,
+        "narHash": "sha256-1ay7Lo2tKRyV/DV8lsSraZvyCurr19FJtqaAkwGZ5zc=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "8a7cb195490f0a0219fafdcbe5bb9fb828be166a",
+        "rev": "2bc614b16d3bfd782563cb05c0e8331d0ebcb1a9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "more-assertions",
         "repo": "auth-keys-hub",
         "type": "github"
       }
@@ -656,13 +657,13 @@
       "locked": {
         "lastModified": 1688568916,
         "narHash": "sha256-XTGTi3PzCcbLL+63JSXTe7mQmGKB0YgEoW1VpqdX2d0=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "6e69a80797f2d68423b25ca7787e81533b367e42",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "13.1.1.3",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -673,13 +674,13 @@
       "locked": {
         "lastModified": 1701131841,
         "narHash": "sha256-mDKE/HqNvDxQ/mQU9j/jthw0NMcTiKHmgswzp0ZHdzM=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "sancho-2-3-0",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -690,13 +691,13 @@
       "locked": {
         "lastModified": 1688568916,
         "narHash": "sha256-XTGTi3PzCcbLL+63JSXTe7mQmGKB0YgEoW1VpqdX2d0=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "6e69a80797f2d68423b25ca7787e81533b367e42",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "13.1.1.3",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -909,13 +910,13 @@
       "locked": {
         "lastModified": 1700615474,
         "narHash": "sha256-pVUWfzVnM4RvpFlJNH2ZmWPZzmkGT1Ty8B1p7NFh69M=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "rev": "34d89af65439db92293b88967c299c20692abc1c",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "8.7.0-pre",
         "repo": "cardano-node",
         "type": "github"
@@ -948,11 +949,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1702769273,
-        "narHash": "sha256-op0zRWC1aFMyqjCcwKsQMC9AWgXWNq8+O0NUzQrxU1U=",
+        "lastModified": 1702960071,
+        "narHash": "sha256-6PacmrjLnMFbc2Ox2rDO0sv80vy9y72TISwG7nv8w+Q=",
         "owner": "input-output-hk",
         "repo": "cardano-parts",
-        "rev": "b1a5e868a0285a9b8adc3460d46af34e18c4edb7",
+        "rev": "56b19d2f7d1583d89e38b8336531e2b009ad895b",
         "type": "github"
       },
       "original": {
@@ -4526,11 +4527,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1690066826,
-        "narHash": "sha256-6L2qb+Zc0BFkh72OS9uuX637gniOjzU6qCDBpjB2LGY=",
+        "lastModified": 1702777222,
+        "narHash": "sha256-/SYmqgxTYzqZnQEfbOCHCN4GzqB9uAIsR9IWLzo0/8I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce45b591975d070044ca24e3003c830d26fea1c8",
+        "rev": "a19a71d1ee93226fd71984359552affbc1cd3dc3",
         "type": "github"
       },
       "original": {
@@ -5012,11 +5013,11 @@
     },
     "nixpkgs_33": {
       "locked": {
-        "lastModified": 1690026219,
-        "narHash": "sha256-oOduRk/kzQxOBknZXTLSEYd7tk+GoKvr8wV6Ab+t4AU=",
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f465da166263bc0d4b39dfd4ca28b777c92d4b73",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
         "type": "github"
       },
       "original": {
@@ -6040,11 +6041,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1690199016,
-        "narHash": "sha256-yTLL72q6aqGmzHq+C3rDp3rIjno7EJZkFLof6Ika7cE=",
+        "lastModified": 1702812162,
+        "narHash": "sha256-18cKptpAAfkatdQgjO5SZXZsbc1IVPRoYx2AxaiooL4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c36df4fe4bf4bb87759b1891cab21e7a05219500",
+        "rev": "21f2b8f123a1601fef3cf6bbbdf5171257290a77",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,6 +51,23 @@
         "type": "github"
       }
     },
+    "CHaP_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702593630,
+        "narHash": "sha256-IWu27+sfPtazjIZiWLUm8G4BKvjXmIL+/1XT/ETnfhg=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "9783a177efcea5beb8808aab7513098bdab185ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -100,6 +117,22 @@
       }
     },
     "HTTP_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_5": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -247,6 +280,36 @@
         "type": "github"
       }
     },
+    "blank_6": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
+    "blank_7": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -349,6 +412,23 @@
         "type": "github"
       }
     },
+    "blst_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656163412,
+        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      }
+    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -401,6 +481,23 @@
       }
     },
     "cabal-32_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_5": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -485,6 +582,23 @@
         "type": "github"
       }
     },
+    "cabal-34_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
       "flake": false,
       "locked": {
@@ -537,6 +651,23 @@
       }
     },
     "cabal-36_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_5": {
       "flake": false,
       "locked": {
         "lastModified": 1669081697,
@@ -637,6 +768,33 @@
           "nixpkgs"
         ],
         "tullia": "tullia_3"
+      },
+      "locked": {
+        "lastModified": 1679408951,
+        "narHash": "sha256-xM78upkrXjRu/739V/IxFrA9m+6rvgOiolt4ReKLAog=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "628f135d243d4a9e388c187e4c6179246038ee72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "type": "github"
+      }
+    },
+    "cardano-automation_4": {
+      "inputs": {
+        "flake-utils": "flake-utils_20",
+        "haskellNix": [
+          "cardano-node-ng",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "nixpkgs"
+        ],
+        "tullia": "tullia_4"
       },
       "locked": {
         "lastModified": 1679408951,
@@ -760,6 +918,25 @@
         "type": "github"
       }
     },
+    "cardano-mainnet-mirror_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_29"
+      },
+      "locked": {
+        "lastModified": 1642701714,
+        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-mainnet-mirror",
+        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "cardano-mainnet-mirror",
+        "type": "github"
+      }
+    },
     "cardano-metadata-service": {
       "flake": false,
       "locked": {
@@ -811,13 +988,13 @@
       "locked": {
         "lastModified": 1690209950,
         "narHash": "sha256-d0V8N+y/OarYv6GQycGXnbPly7GeJRBEeE1017qj9eI=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "8.1.2",
         "repo": "cardano-node",
         "type": "github"
@@ -852,13 +1029,13 @@
       "locked": {
         "lastModified": 1691329439,
         "narHash": "sha256-CPB2O5/QeQrV8EQQwEICTJQE1cp3KeUEh43ZICbE338=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "rev": "a29ee68ba2c850cd50be39a3105ef191cfbc41d5",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "8.2.1-pre",
         "repo": "cardano-node",
         "type": "github"
@@ -891,16 +1068,57 @@
         "utils": "utils_6"
       },
       "locked": {
-        "lastModified": 1695212709,
-        "narHash": "sha256-d9iIKoFWd3JvexcjXTEILhmqC/o2w/NXfn0yPw5WufQ=",
-        "owner": "input-output-hk",
+        "lastModified": 1696947894,
+        "narHash": "sha256-5v07pG/NruF3UgRATIgy7ruVsST/aEewVhrypelFQK8=",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "52e9e4487f153213fe29e9f9f507079fef9be67c",
+        "rev": "274c2e15e7d55bca8a0802648177db7653a9aa72",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "utxo-hd-8.2.1",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
+    "cardano-node-ng": {
+      "inputs": {
+        "CHaP": "CHaP_4",
+        "cardano-automation": "cardano-automation_4",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_4",
+        "customConfig": "customConfig_4",
+        "em": "em_4",
+        "empty-flake": "empty-flake_4",
+        "flake-compat": "flake-compat_13",
+        "hackageNix": "hackageNix_4",
+        "haskellNix": "haskellNix_4",
+        "hostNixpkgs": [
+          "cardano-node-ng",
+          "nixpkgs"
+        ],
+        "iohkNix": "iohkNix_4",
+        "nix2container": "nix2container_8",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "ops-lib": "ops-lib_4",
+        "std": "std_7",
+        "utils": "utils_8"
+      },
+      "locked": {
+        "lastModified": 1702654749,
+        "narHash": "sha256-fIzSNSKWC7qMRjHUMHfrMnEzHiFu7ac/UUgfofXqaFY=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "a4a8119b59b1fbb9a69c79e1e6900e91292161e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "8.7.3",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -933,15 +1151,15 @@
         "cardano-node-service": "cardano-node-service",
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
-        "empty-flake": "empty-flake_4",
+        "empty-flake": "empty-flake_5",
         "flake-parts": "flake-parts_2",
         "haskell-nix": "haskell-nix",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
-        "nix": "nix_5",
-        "nixpkgs": "nixpkgs_32",
-        "nixpkgs-unstable": "nixpkgs-unstable_5",
+        "nix": "nix_6",
+        "nixpkgs": "nixpkgs_41",
+        "nixpkgs-unstable": "nixpkgs-unstable_6",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
         "sops-nix": "sops-nix",
@@ -1027,6 +1245,22 @@
         "type": "github"
       }
     },
+    "cardano-shell_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
     "cardano-wallet-service": {
       "flake": false,
       "locked": {
@@ -1046,8 +1280,8 @@
     },
     "colmena": {
       "inputs": {
-        "flake-compat": "flake-compat_12",
-        "flake-utils": "flake-utils_20",
+        "flake-compat": "flake-compat_16",
+        "flake-utils": "flake-utils_26",
         "nixpkgs": [
           "cardano-parts",
           "nixpkgs"
@@ -1121,6 +1355,32 @@
         "type": "github"
       }
     },
+    "crane_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_15",
+        "flake-utils": "flake-utils_25",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "paisano-mdbook-preprocessor",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_3"
+      },
+      "locked": {
+        "lastModified": 1676162383,
+        "narHash": "sha256-krUCKdz7ebHlFYm/A7IbKDnj2ZmMMm3yIEQcooqm7+E=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fb400ec631b22ccdbc7090b38207f7fb5cfb5f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -1152,6 +1412,21 @@
       }
     },
     "customConfig_3": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_4": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -1288,6 +1563,60 @@
           "nixpkgs"
         ],
         "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1686680692,
+        "narHash": "sha256-SsLZz3TDleraAiJq4EkmdyewSyiv5g0LZYc6vaLZOMQ=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "fd6223370774dd9c33354e87a007004b5fd36442",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_6": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_7": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1686680692,
@@ -1462,6 +1791,71 @@
         "type": "github"
       }
     },
+    "dmerge_6": {
+      "inputs": {
+        "nixlib": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ],
+        "yants": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1659548052,
+        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
+        "owner": "divnix",
+        "repo": "data-merge",
+        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "data-merge",
+        "type": "github"
+      }
+    },
+    "dmerge_7": {
+      "inputs": {
+        "haumea": [
+          "cardano-node-ng",
+          "std",
+          "haumea"
+        ],
+        "nixlib": [
+          "cardano-node-ng",
+          "std",
+          "haumea",
+          "nixpkgs"
+        ],
+        "yants": [
+          "cardano-node-ng",
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686862774,
+        "narHash": "sha256-ojGtRQ9pIOUrxsQEuEPerUkqIJEuod9hIflfNkY+9CE=",
+        "owner": "divnix",
+        "repo": "dmerge",
+        "rev": "9f7f7a8349d33d7bd02e0f2b484b1f076e503a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "ref": "0.2.1",
+        "repo": "dmerge",
+        "type": "github"
+      }
+    },
     "em": {
       "flake": false,
       "locked": {
@@ -1495,6 +1889,22 @@
       }
     },
     "em_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684791668,
+        "narHash": "sha256-JyPm0RiWCfy/8rs7wd/IRSWIz+bTkD78uxIMnKktU2g=",
+        "owner": "deepfire",
+        "repo": "em",
+        "rev": "302cdf6d654fb18baff0213bdfa41a653774585a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "deepfire",
+        "repo": "em",
+        "type": "github"
+      }
+    },
+    "em_4": {
       "flake": false,
       "locked": {
         "lastModified": 1684791668,
@@ -1570,6 +1980,21 @@
         "type": "github"
       }
     },
+    "empty-flake_5": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": "nixpkgs_16",
@@ -1593,6 +2018,25 @@
       "inputs": {
         "nixpkgs": "nixpkgs_25",
         "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1677306201,
+        "narHash": "sha256-VZ9x7qdTosFvVsrpgFHrtYfT6PU3yMIs7NRYn9ELapI=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0923f0c162f65ae40261ec940406049726cfeab4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_34",
+        "rust-analyzer-src": "rust-analyzer-src_3"
       },
       "locked": {
         "lastModified": 1677306201,
@@ -1677,6 +2121,23 @@
     "flake-compat_13": {
       "flake": false,
       "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_14": {
+      "flake": false,
+      "locked": {
         "lastModified": 1672831974,
         "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
@@ -1691,7 +2152,56 @@
         "type": "github"
       }
     },
-    "flake-compat_14": {
+    "flake-compat_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_18": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -2077,6 +2587,36 @@
     },
     "flake-utils_20": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_21": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_22": {
+      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -2090,7 +2630,67 @@
         "type": "github"
       }
     },
-    "flake-utils_21": {
+    "flake-utils_23": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_24": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_25": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_26": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_27": {
       "locked": {
         "lastModified": 1679360468,
         "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
@@ -2106,7 +2706,7 @@
         "type": "github"
       }
     },
-    "flake-utils_22": {
+    "flake-utils_28": {
       "locked": {
         "lastModified": 1634851050,
         "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
@@ -2295,6 +2895,60 @@
         "type": "github"
       }
     },
+    "ghc-8.6.5-iohk_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697054644,
+        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "ref": "refs/heads/master",
+        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
+        "revCount": 62040,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "gomod2nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_4",
@@ -2337,6 +2991,25 @@
       "inputs": {
         "nixpkgs": "nixpkgs_17",
         "utils": "utils_5"
+      },
+      "locked": {
+        "lastModified": 1655245309,
+        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "gomod2nix_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_26",
+        "utils": "utils_7"
       },
       "locked": {
         "lastModified": 1655245309,
@@ -2416,35 +3089,51 @@
         "type": "github"
       }
     },
+    "hackageNix_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701303758,
+        "narHash": "sha256-8XqVEQwmJBxRPFa7SizJuZxbG+NFEZKWdhtYPTQ7ZKM=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "8a0e3ae9295b7ef8431b9be208dd06aa2789be53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
-        "HTTP": "HTTP_4",
-        "cabal-32": "cabal-32_4",
-        "cabal-34": "cabal-34_4",
-        "cabal-36": "cabal-36_4",
-        "cardano-shell": "cardano-shell_4",
-        "flake-compat": "flake-compat_13",
-        "flake-utils": "flake-utils_21",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
+        "HTTP": "HTTP_5",
+        "cabal-32": "cabal-32_5",
+        "cabal-34": "cabal-34_5",
+        "cabal-36": "cabal-36_5",
+        "cardano-shell": "cardano-shell_5",
+        "flake-compat": "flake-compat_17",
+        "flake-utils": "flake-utils_27",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
         "hackage": "hackage",
-        "hls-1.10": "hls-1.10_4",
-        "hls-2.0": "hls-2.0_3",
-        "hpc-coveralls": "hpc-coveralls_4",
-        "hydra": "hydra_4",
-        "iserv-proxy": "iserv-proxy_4",
+        "hls-1.10": "hls-1.10_5",
+        "hls-2.0": "hls-2.0_4",
+        "hpc-coveralls": "hpc-coveralls_5",
+        "hydra": "hydra_5",
+        "iserv-proxy": "iserv-proxy_5",
         "nixpkgs": [
           "cardano-parts",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_4",
-        "nixpkgs-2105": "nixpkgs-2105_4",
-        "nixpkgs-2111": "nixpkgs-2111_4",
-        "nixpkgs-2205": "nixpkgs-2205_4",
-        "nixpkgs-2211": "nixpkgs-2211_4",
-        "nixpkgs-2305": "nixpkgs-2305_3",
-        "nixpkgs-unstable": "nixpkgs-unstable_4",
-        "old-ghc-nix": "old-ghc-nix_4",
+        "nixpkgs-2003": "nixpkgs-2003_5",
+        "nixpkgs-2105": "nixpkgs-2105_5",
+        "nixpkgs-2111": "nixpkgs-2111_5",
+        "nixpkgs-2205": "nixpkgs-2205_5",
+        "nixpkgs-2211": "nixpkgs-2211_5",
+        "nixpkgs-2305": "nixpkgs-2305_4",
+        "nixpkgs-unstable": "nixpkgs-unstable_5",
+        "old-ghc-nix": "old-ghc-nix_5",
         "stackage": [
           "cardano-parts",
           "empty-flake"
@@ -2603,6 +3292,57 @@
         "type": "github"
       }
     },
+    "haskellNix_4": {
+      "inputs": {
+        "HTTP": "HTTP_4",
+        "cabal-32": "cabal-32_4",
+        "cabal-34": "cabal-34_4",
+        "cabal-36": "cabal-36_4",
+        "cardano-shell": "cardano-shell_4",
+        "flake-compat": "flake-compat_14",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
+        "ghc98X": "ghc98X",
+        "ghc99": "ghc99",
+        "hackage": [
+          "cardano-node-ng",
+          "hackageNix"
+        ],
+        "hls-1.10": "hls-1.10_4",
+        "hls-2.0": "hls-2.0_3",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hpc-coveralls": "hpc-coveralls_4",
+        "hydra": "hydra_4",
+        "iserv-proxy": "iserv-proxy_4",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_4",
+        "nixpkgs-2105": "nixpkgs-2105_4",
+        "nixpkgs-2111": "nixpkgs-2111_4",
+        "nixpkgs-2205": "nixpkgs-2205_4",
+        "nixpkgs-2211": "nixpkgs-2211_4",
+        "nixpkgs-2305": "nixpkgs-2305_3",
+        "nixpkgs-unstable": "nixpkgs-unstable_4",
+        "old-ghc-nix": "old-ghc-nix_4",
+        "stackage": "stackage_4"
+      },
+      "locked": {
+        "lastModified": 1700441391,
+        "narHash": "sha256-oJqP1AUskUvr3GNUH97eKwaIUHdYgENS2kQ7GI9RI+c=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "3b6056f3866f88d1d16eaeb2e810d3ac0df0e7cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "haumea": {
       "inputs": {
         "nixpkgs": "nixpkgs_14"
@@ -2625,6 +3365,25 @@
     "haumea_2": {
       "inputs": {
         "nixpkgs": "nixpkgs_23"
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "haumea_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_32"
       },
       "locked": {
         "lastModified": 1685133229,
@@ -2709,6 +3468,23 @@
         "type": "github"
       }
     },
+    "hls-1.10_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.0": {
       "flake": false,
       "locked": {
@@ -2756,6 +3532,74 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696939266,
+        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -2809,6 +3653,22 @@
       }
     },
     "hpc-coveralls_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_5": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -2899,6 +3759,30 @@
     "hydra_4": {
       "inputs": {
         "nix": "nix_4",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_5": {
+      "inputs": {
+        "nix": "nix_5",
         "nixpkgs": [
           "cardano-parts",
           "haskell-nix",
@@ -3037,6 +3921,53 @@
         "type": "github"
       }
     },
+    "incl_6": {
+      "inputs": {
+        "nixlib": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_7": {
+      "inputs": {
+        "nixlib": [
+          "cardano-node-ng",
+          "std",
+          "haumea",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
     "inclusive": {
       "inputs": {
         "stdlib": "stdlib"
@@ -3058,7 +3989,7 @@
     "inputs-check": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_28"
+        "nixpkgs": "nixpkgs_37"
       },
       "locked": {
         "lastModified": 1692633913,
@@ -3076,10 +4007,10 @@
     },
     "iohk-nix": {
       "inputs": {
-        "blst": "blst_4",
-        "nixpkgs": "nixpkgs_29",
-        "secp256k1": "secp256k1_4",
-        "sodium": "sodium_4"
+        "blst": "blst_5",
+        "nixpkgs": "nixpkgs_38",
+        "secp256k1": "secp256k1_5",
+        "sodium": "sodium_5"
       },
       "locked": {
         "lastModified": 1702057058,
@@ -3097,10 +4028,10 @@
     },
     "iohk-nix-legacy": {
       "inputs": {
-        "blst": "blst_6",
-        "nixpkgs": "nixpkgs_35",
-        "secp256k1": "secp256k1_6",
-        "sodium": "sodium_6"
+        "blst": "blst_7",
+        "nixpkgs": "nixpkgs_44",
+        "secp256k1": "secp256k1_7",
+        "sodium": "sodium_7"
       },
       "locked": {
         "lastModified": 1701181091,
@@ -3119,10 +4050,10 @@
     },
     "iohk-nix-ng": {
       "inputs": {
-        "blst": "blst_5",
-        "nixpkgs": "nixpkgs_30",
-        "secp256k1": "secp256k1_5",
-        "sodium": "sodium_5"
+        "blst": "blst_6",
+        "nixpkgs": "nixpkgs_39",
+        "secp256k1": "secp256k1_6",
+        "sodium": "sodium_6"
       },
       "locked": {
         "lastModified": 1702057058,
@@ -3210,6 +4141,30 @@
         "type": "github"
       }
     },
+    "iohkNix_4": {
+      "inputs": {
+        "blst": "blst_4",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_4",
+        "sodium": "sodium_4"
+      },
+      "locked": {
+        "lastModified": 1698746924,
+        "narHash": "sha256-8og+vqQPEoB2KLUtN5esGMDymT+2bT/rCHZt1NAe7y0=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "af551ca93d969d9715fa9bf86691d9a0a19e89d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -3262,6 +4217,23 @@
       }
     },
     "iserv-proxy_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
+        "ref": "hkm/remote-iserv",
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "iserv-proxy_5": {
       "flake": false,
       "locked": {
         "lastModified": 1688517130,
@@ -3343,6 +4315,22 @@
       }
     },
     "lowdown-src_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_6": {
       "flake": false,
       "locked": {
         "lastModified": 1633514407,
@@ -3503,6 +4491,64 @@
         "type": "github"
       }
     },
+    "n2c_6": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677330646,
+        "narHash": "sha256-hUYCwJneMjnxTvj30Fjow6UMJUITqHlpUGpXMPXUJsU=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "ebca8f58d450cae1a19c07701a5a8ae40afc9efc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "n2c_7": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685771919,
+        "narHash": "sha256-3lVKWrhNXjHJB6QkZ2SJaOs4X/mmYXtY6ovPVpDMOHc=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "95e2220911874064b5d809f8d35f7835184c4ddf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -3616,6 +4662,44 @@
         ],
         "nixpkgs-lib": [
           "cardano-node-hd",
+          "cardano-automation",
+          "tullia",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1658277770,
+        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "type": "github"
+      }
+    },
+    "nix-nomad_4": {
+      "inputs": {
+        "flake-compat": "flake-compat_12",
+        "flake-utils": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "nix2container",
+          "flake-utils"
+        ],
+        "gomod2nix": "gomod2nix_4",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "nixpkgs"
+        ],
+        "nixpkgs-lib": [
+          "cardano-node-ng",
           "cardano-automation",
           "tullia",
           "nixpkgs"
@@ -3749,6 +4833,44 @@
         "type": "github"
       }
     },
+    "nix2container_7": {
+      "inputs": {
+        "flake-utils": "flake-utils_21",
+        "nixpkgs": "nixpkgs_27"
+      },
+      "locked": {
+        "lastModified": 1658567952,
+        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nix2container_8": {
+      "inputs": {
+        "flake-utils": "flake-utils_23",
+        "nixpkgs": "nixpkgs_31"
+      },
+      "locked": {
+        "lastModified": 1671269339,
+        "narHash": "sha256-KR2SXh4c2Y+bgbCfXjTGJ74O9/u4CAPFA0KYZHhKf5Q=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "6800fff45afecc7e47c334d14cf2b2f4f25601a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
@@ -3794,7 +4916,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_27",
+        "nixpkgs": "nixpkgs_30",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -3814,10 +4936,31 @@
     },
     "nix_5": {
       "inputs": {
-        "flake-compat": "flake-compat_14",
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_31",
+        "nixpkgs": "nixpkgs_36",
         "nixpkgs-regression": "nixpkgs-regression_5"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_6": {
+      "inputs": {
+        "flake-compat": "flake-compat_18",
+        "lowdown-src": "lowdown-src_6",
+        "nixpkgs": "nixpkgs_40",
+        "nixpkgs-regression": "nixpkgs-regression_6"
       },
       "locked": {
         "lastModified": 1701705406,
@@ -4009,6 +5152,76 @@
         "type": "github"
       }
     },
+    "nixago_6": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixago-exts": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676075813,
+        "narHash": "sha256-X/aIT8Qc8UCqnxJvaZykx3CJ0ZnDFvO+dqp/7fglZWo=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "9cab4dde31ec2f2c05d702ea8648ce580664e906",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixago_7": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "std",
+          "flake-utils"
+        ],
+        "nixago-exts": [
+          "cardano-node-ng",
+          "std",
+          "blank"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683210100,
+        "narHash": "sha256-bhGDOlkWtlhVECpoOog4fWiFJmLCpVEg09a40aTjCbw=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "1da60ad9412135f9ed7a004669fdcf3d378ec630",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1642336556,
@@ -4072,6 +5285,22 @@
       }
     },
     "nixpkgs-2003_4": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_5": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -4151,6 +5380,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2105_5": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2111": {
       "locked": {
         "lastModified": 1659446231,
@@ -4200,6 +5445,22 @@
       }
     },
     "nixpkgs-2111_4": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_5": {
       "locked": {
         "lastModified": 1659446231,
         "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
@@ -4279,6 +5540,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2205_5": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2211": {
       "locked": {
         "lastModified": 1682682915,
@@ -4343,6 +5620,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2211_5": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2305": {
       "locked": {
         "lastModified": 1685338297,
@@ -4376,6 +5669,22 @@
       }
     },
     "nixpkgs-2305_3": {
+      "locked": {
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_4": {
       "locked": {
         "lastModified": 1690680713,
         "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
@@ -4525,6 +5834,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression_6": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1702777222,
@@ -4591,6 +5916,22 @@
     },
     "nixpkgs-unstable_4": {
       "locked": {
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_5": {
+      "locked": {
         "lastModified": 1690720142,
         "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
         "owner": "NixOS",
@@ -4605,7 +5946,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable_5": {
+    "nixpkgs-unstable_6": {
       "locked": {
         "lastModified": 1701626906,
         "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
@@ -4886,15 +6227,15 @@
     },
     "nixpkgs_26": {
       "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
-        "owner": "nixos",
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -4902,50 +6243,47 @@
     },
     "nixpkgs_27": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1654807842,
+        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_28": {
       "locked": {
-        "lastModified": 1692339729,
-        "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae521bd4e460b076a455dca8b13f4151489a725c",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_29": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs_3": {
@@ -4965,6 +6303,132 @@
     },
     "nixpkgs_30": {
       "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_31": {
+      "locked": {
+        "lastModified": 1654807842,
+        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_32": {
+      "locked": {
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_33": {
+      "locked": {
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_34": {
+      "locked": {
+        "lastModified": 1677063315,
+        "narHash": "sha256-qiB4ajTeAOVnVSAwCNEEkoybrAlA+cpeiBxLobHndE8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "988cc958c57ce4350ec248d2d53087777f9e1949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_35": {
+      "locked": {
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_36": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_37": {
+      "locked": {
+        "lastModified": 1692339729,
+        "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ae521bd4e460b076a455dca8b13f4151489a725c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_38": {
+      "locked": {
         "lastModified": 1684171562,
         "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
         "owner": "nixos",
@@ -4979,70 +6443,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_31": {
-      "locked": {
-        "lastModified": 1700748986,
-        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_32": {
-      "locked": {
-        "lastModified": 1701539137,
-        "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "933d7dc155096e7575d207be6fb7792bc9f34f6d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_33": {
-      "locked": {
-        "lastModified": 1702539185,
-        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_34": {
-      "locked": {
-        "lastModified": 1636823747,
-        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_35": {
+    "nixpkgs_39": {
       "locked": {
         "lastModified": 1684171562,
         "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
@@ -5070,6 +6471,85 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_40": {
+      "locked": {
+        "lastModified": 1700748986,
+        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_41": {
+      "locked": {
+        "lastModified": 1701539137,
+        "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "933d7dc155096e7575d207be6fb7792bc9f34f6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_42": {
+      "locked": {
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_43": {
+      "locked": {
+        "lastModified": 1636823747,
+        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_44": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5227,6 +6707,36 @@
         "type": "github"
       }
     },
+    "nosys_6": {
+      "locked": {
+        "lastModified": 1668010795,
+        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
+    "nosys_7": {
+      "locked": {
+        "lastModified": 1668010795,
+        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -5295,6 +6805,23 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "opentofu-registry": {
       "flake": false,
       "locked": {
@@ -5344,6 +6871,22 @@
       }
     },
     "ops-lib_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675186784,
+        "narHash": "sha256-HqDtrvk1l7YeREzCSEpUtChtlEgT6Tww9WrJiozjukc=",
+        "owner": "input-output-hk",
+        "repo": "ops-lib",
+        "rev": "5be29ed53b2a4cbbf4cf326fa2e9c1f2b754d26d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ops-lib",
+        "type": "github"
+      }
+    },
+    "ops-lib_4": {
       "flake": false,
       "locked": {
         "lastModified": 1675186784,
@@ -5437,6 +6980,29 @@
         "type": "github"
       }
     },
+    "paisano-actions_3": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "paisano-mdbook-preprocessor",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677306424,
+        "narHash": "sha256-H9/dI2rGEbKo4KEisqbRPHFG2ajF8Tm111NPdKGIf28=",
+        "owner": "paisano-nix",
+        "repo": "actions",
+        "rev": "65ec4e080b3480167fc1a748c89a05901eea9a9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "actions",
+        "type": "github"
+      }
+    },
     "paisano-mdbook-preprocessor": {
       "inputs": {
         "crane": "crane",
@@ -5478,6 +7044,35 @@
         "paisano-actions": "paisano-actions_2",
         "std": [
           "cardano-node-hd",
+          "std"
+        ]
+      },
+      "locked": {
+        "lastModified": 1680654400,
+        "narHash": "sha256-Qdpio+ldhUK3zfl22Mhf8HUULdUOJXDWDdO7MIK69OU=",
+        "owner": "paisano-nix",
+        "repo": "mdbook-paisano-preprocessor",
+        "rev": "11a8fc47f574f194a7ae7b8b98001f6143ba4cf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "mdbook-paisano-preprocessor",
+        "type": "github"
+      }
+    },
+    "paisano-mdbook-preprocessor_3": {
+      "inputs": {
+        "crane": "crane_3",
+        "fenix": "fenix_3",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "nixpkgs"
+        ],
+        "paisano-actions": "paisano-actions_3",
+        "std": [
+          "cardano-node-ng",
           "std"
         ]
       },
@@ -5609,6 +7204,63 @@
         "type": "github"
       }
     },
+    "paisano-tui_5": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "std": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677533603,
+        "narHash": "sha256-Nq1dH/qn7Wg/Tj1+id+ZM3o0fzqonW73jAgY3mCp35M=",
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "rev": "802958d123b0a5437441be0cab1dee487b0ed3eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "type": "github"
+      }
+    },
+    "paisano-tui_6": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "blank"
+        ],
+        "std": [
+          "cardano-node-ng",
+          "std"
+        ]
+      },
+      "locked": {
+        "lastModified": 1681847764,
+        "narHash": "sha256-mdd7PJW1BZvxy0cIKsPfAO+ohVl/V7heE5ZTAHzTdv8=",
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "rev": "3096bad91cae73ab8ab3367d31f8a143d248a244",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "ref": "0.1.1",
+        "repo": "tui",
+        "type": "github"
+      }
+    },
     "paisano_2": {
       "inputs": {
         "nixpkgs": [
@@ -5699,6 +7351,67 @@
         "type": "github"
       }
     },
+    "paisano_5": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ],
+        "nosys": "nosys_6",
+        "yants": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677437285,
+        "narHash": "sha256-YGfMothgUq1T9wMJYEhOSvdIiD/8gLXO1YcZA6hyIWU=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "5f2fc05e98e001cb1cf9535ded09e05d90cec131",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "core",
+        "type": "github"
+      }
+    },
+    "paisano_6": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "std",
+          "nixpkgs"
+        ],
+        "nosys": "nosys_7",
+        "yants": [
+          "cardano-node-ng",
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686862844,
+        "narHash": "sha256-m8l/HpRBJnZ3c0F1u0IyQ3nYGWE0R9V5kfORuqZPzgk=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "6674b3d3577212c1eeecd30d62d52edbd000e726",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "ref": "0.1.1",
+        "repo": "core",
+        "type": "github"
+      }
+    },
     "process-compose-flake": {
       "locked": {
         "lastModified": 1701368682,
@@ -5719,6 +7432,7 @@
         "cardano-node": "cardano-node",
         "cardano-node-821-pre": "cardano-node-821-pre",
         "cardano-node-hd": "cardano-node-hd",
+        "cardano-node-ng": "cardano-node-ng",
         "cardano-parts": "cardano-parts",
         "flake-parts": [
           "cardano-parts",
@@ -5753,6 +7467,23 @@
       }
     },
     "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677221702,
+        "narHash": "sha256-1M+58rC4eTCWNmmX0hQVZP20t3tfYNunl9D/PrGUyGE=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "f5401f620699b26ed9d47a1d2e838143a18dbe3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1677221702,
@@ -5811,6 +7542,37 @@
         ],
         "nixpkgs": [
           "cardano-node-hd",
+          "std",
+          "paisano-mdbook-preprocessor",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675391458,
+        "narHash": "sha256-ukDKZw922BnK5ohL9LhwtaDAdCsJL7L6ScNEyF1lO9w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "383a4acfd11d778d5c2efcf28376cbd845eeaedf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "flake-utils": [
+          "cardano-node-ng",
+          "std",
+          "paisano-mdbook-preprocessor",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "cardano-node-ng",
           "std",
           "paisano-mdbook-preprocessor",
           "crane",
@@ -5933,6 +7695,23 @@
         "type": "github"
       }
     },
+    "secp256k1_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
     "sodium": {
       "flake": false,
       "locked": {
@@ -6035,9 +7814,26 @@
         "type": "github"
       }
     },
+    "sodium_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_33",
+        "nixpkgs": "nixpkgs_42",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -6110,6 +7906,22 @@
         "owner": "input-output-hk",
         "repo": "stackage.nix",
         "rev": "c91713e7ca38abba6a90686df895acda53fd5038",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700438989,
+        "narHash": "sha256-x+7Qtboko7ds8CU8pq2sIZiD45DauYoX9LxBfwQr/hs=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "9c2015334cc77837b8454b3b10ef4f711a256f6f",
         "type": "github"
       },
       "original": {
@@ -6351,6 +8163,100 @@
         "type": "github"
       }
     },
+    "std_6": {
+      "inputs": {
+        "arion": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "blank": "blank_6",
+        "devshell": "devshell_6",
+        "dmerge": "dmerge_6",
+        "flake-utils": "flake-utils_22",
+        "incl": "incl_6",
+        "makes": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "n2c": "n2c_6",
+        "nixago": "nixago_6",
+        "nixpkgs": "nixpkgs_28",
+        "paisano": "paisano_5",
+        "paisano-tui": "paisano-tui_5",
+        "yants": "yants_6"
+      },
+      "locked": {
+        "lastModified": 1677533652,
+        "narHash": "sha256-H37dcuWAGZs6Yl9mewMNVcmSaUXR90/bABYFLT/nwhk=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "490542f624412662e0411d8cb5a9af988ef56633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
+    "std_7": {
+      "inputs": {
+        "arion": [
+          "cardano-node-ng",
+          "std",
+          "blank"
+        ],
+        "blank": "blank_7",
+        "devshell": "devshell_7",
+        "dmerge": "dmerge_7",
+        "flake-utils": "flake-utils_24",
+        "haumea": "haumea_3",
+        "incl": "incl_7",
+        "makes": [
+          "cardano-node-ng",
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "cardano-node-ng",
+          "std",
+          "blank"
+        ],
+        "n2c": "n2c_7",
+        "nixago": "nixago_7",
+        "nixpkgs": "nixpkgs_33",
+        "paisano": "paisano_6",
+        "paisano-mdbook-preprocessor": "paisano-mdbook-preprocessor_3",
+        "paisano-tui": "paisano-tui_6",
+        "yants": "yants_7"
+      },
+      "locked": {
+        "lastModified": 1687300684,
+        "narHash": "sha256-oBqbss0j+B568GoO3nF2BCoPEgPxUjxfZQGynW6mhEk=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "80e5792eae98353a97ab1e85f3fba2784e4a3690",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -6396,12 +8302,27 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "terranix": {
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
-        "flake-utils": "flake-utils_22",
-        "nixpkgs": "nixpkgs_34",
+        "flake-utils": "flake-utils_28",
+        "nixpkgs": "nixpkgs_43",
         "terranix-examples": "terranix-examples"
       },
       "locked": {
@@ -6435,7 +8356,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_26"
+        "nixpkgs": "nixpkgs_35"
       },
       "locked": {
         "lastModified": 1683117219,
@@ -6543,6 +8464,31 @@
         "type": "github"
       }
     },
+    "tullia_4": {
+      "inputs": {
+        "nix-nomad": "nix-nomad_4",
+        "nix2container": "nix2container_7",
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "nixpkgs"
+        ],
+        "std": "std_6"
+      },
+      "locked": {
+        "lastModified": 1684859161,
+        "narHash": "sha256-wOKutImA7CRL0rN+Ng80E72fD5FkVub7LLP2k9NICpg=",
+        "owner": "input-output-hk",
+        "repo": "tullia",
+        "rev": "2964cff1a16eefe301bdddb508c49d94d04603d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "tullia",
+        "type": "github"
+      }
+    },
     "utils": {
       "locked": {
         "lastModified": 1653893745,
@@ -6619,6 +8565,36 @@
       }
     },
     "utils_6": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_7": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_8": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -6731,6 +8707,53 @@
       "inputs": {
         "nixpkgs": [
           "cardano-node-hd",
+          "std",
+          "haumea",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686863218,
+        "narHash": "sha256-kooxYm3/3ornWtVBNHM3Zh020gACUyFX2G0VQXnB+mk=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "8f0da0dba57149676aa4817ec0c880fbde7a648d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
+      }
+    },
+    "yants_6": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
+          "cardano-automation",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
+      }
+    },
+    "yants_7": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-ng",
           "std",
           "haumea",
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,9 @@
     # cardano-parts.url = "path:/home/jlotoski/work/iohk/cardano-parts-wt/next-2023-12-18";
 
     # Local pins for additional customization:
-    cardano-node.url = "github:input-output-hk/cardano-node/8.1.2";
-    cardano-node-821-pre.url = "github:input-output-hk/cardano-node/8.2.1-pre";
-    cardano-node-hd.url = "github:input-output-hk/cardano-node/utxo-hd-8.2.1";
+    cardano-node.url = "github:IntersectMBO/cardano-node/8.1.2";
+    cardano-node-821-pre.url = "github:IntersectMBO/cardano-node/8.2.1-pre";
+    cardano-node-hd.url = "github:IntersectMBO/cardano-node/utxo-hd-8.2.1";
 
     # For cardano-node service local debug:
     # cardano-node-service = {
@@ -19,6 +19,10 @@
     #   flake = false;
     # };
 
+    # Until node-8.7.3 is in capkgs with IntersectMBO script fix
+    cardano-node-ng.url = "github:IntersectMBO/cardano-node/8.7.3";
+
+    # For HD testing
     iohk-nix-legacy.url = "github:input-output-hk/iohk-nix/migrate-to-play-legacy";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
 
     # For HD testing
     iohk-nix-legacy.url = "github:input-output-hk/iohk-nix/migrate-to-play-legacy";
+
+    # Voltaire backend swagger ui for private chain deployment
+    vva.url = "github:input-output-hk/voltaire-era/flake";
   };
 
   outputs = inputs: let

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs-unstable.follows = "cardano-parts/nixpkgs-unstable";
     flake-parts.follows = "cardano-parts/flake-parts";
     cardano-parts.url = "github:input-output-hk/cardano-parts/next-2023-12-18";
-    # cardano-parts.url = "path:/home/jlotoski/work/iohk/cardano-parts-wt/next-2023-12-18";
+    # cardano-parts.url = "path:/home/jlotoski/work/iohk/cardano-parts-wt/cardano-playground";
 
     # Local pins for additional customization:
     cardano-node.url = "github:IntersectMBO/cardano-node/8.1.2";
@@ -26,7 +26,7 @@
     iohk-nix-legacy.url = "github:input-output-hk/iohk-nix/migrate-to-play-legacy";
 
     # Voltaire backend swagger ui for private chain deployment
-    vva.url = "github:input-output-hk/voltaire-era/flake";
+    govtool.url = "github:IntersectMBO/govtool/flake";
   };
 
   outputs = inputs: let

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -75,7 +75,7 @@ in
             groupCfg = nixos.config.cardano-parts.cluster.group;
             opsLib = config.flake.cardano-parts.lib.opsLib nixos.pkgs;
           in {
-            environment.systemPackages = [inputs.vva.packages.x86_64-linux.vva-be];
+            environment.systemPackages = [inputs.govtool.packages.x86_64-linux.vva-be];
 
             systemd.services.vva-be = {
               wantedBy = ["multi-user.target"];
@@ -84,7 +84,7 @@ in
               serviceConfig = {
                 ExecStart = lib.getExe (pkgs.writeShellApplication {
                   name = "vva-be";
-                  runtimeInputs = [inputs.vva.packages.x86_64-linux.vva-be];
+                  runtimeInputs = [inputs.govtool.packages.x86_64-linux.vva-be];
                   text = "vva-be -c /run/secrets/vva-be-cfg.json start-app";
                 });
                 Restart = "always";

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -6,414 +6,420 @@
 }: let
   inherit (config.flake) nixosModules nixosConfigurations;
   inherit (config.flake.cardano-parts.cluster.infra.aws) domain;
-in {
-  flake.colmena = let
-    # Region defs:
-    eu-central-1.aws.region = "eu-central-1";
-    eu-west-1.aws.region = "eu-west-1";
-    us-east-2.aws.region = "us-east-2";
+in
+  with builtins;
+  with lib; {
+    flake.colmena = let
+      # Region defs:
+      eu-central-1.aws.region = "eu-central-1";
+      eu-west-1.aws.region = "eu-west-1";
+      us-east-2.aws.region = "us-east-2";
 
-    # Instance defs:
-    t3a-micro.aws.instance.instance_type = "t3a.micro";
-    t3a-small.aws.instance.instance_type = "t3a.small";
-    t3a-medium.aws.instance.instance_type = "t3a.medium";
-    m5a-large.aws.instance.instance_type = "m5a.large";
-    r5-xlarge.aws.instance.instance_type = "r5.xlarge";
-    r5-2xlarge.aws.instance.instance_type = "r5.2xlarge";
+      # Instance defs:
+      t3a-micro.aws.instance.instance_type = "t3a.micro";
+      t3a-small.aws.instance.instance_type = "t3a.small";
+      t3a-medium.aws.instance.instance_type = "t3a.medium";
+      m5a-large.aws.instance.instance_type = "m5a.large";
+      r5-large.aws.instance.instance_type = "r5.large";
+      r5-xlarge.aws.instance.instance_type = "r5.xlarge";
+      r5-2xlarge.aws.instance.instance_type = "r5.2xlarge";
 
-    # Helper fns:
-    ebs = size: {aws.instance.root_block_device.volume_size = lib.mkDefault size;};
+      # Helper fns:
+      ebs = size: {aws.instance.root_block_device.volume_size = mkDefault size;};
+      # ebsIops = iops: {aws.instance.root_block_device.iops = mkDefault iops;};
+      # ebsTp = tp: {aws.instance.root_block_device.throughput = mkDefault tp;};
+      # ebsHighPerf = recursiveUpdate (ebsIops 10000) (ebsTp 1000);
 
-    # Helper defs:
-    # delete.aws.instance.count = 0;
+      # Helper defs:
+      # delete.aws.instance.count = 0;
 
-    # Cardano group assignments:
-    group = name: {
-      cardano-parts.cluster.group = config.flake.cardano-parts.cluster.groups.${name};
+      # Cardano group assignments:
+      group = name: {
+        cardano-parts.cluster.group = config.flake.cardano-parts.cluster.groups.${name};
 
-      # Since all machines are assigned a group, this is a good place to include default aws instance tags
-      aws.instance.tags = {
-        inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
-        environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
-        group = name;
-      };
-    };
-
-    # Cardano-node modules for group deployment
-    node = {
-      imports = [
-        # Base cardano-node service
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
-
-        # Config for cardano-node group deployments
-        inputs.cardano-parts.nixosModules.profile-cardano-node-group
-      ];
-    };
-
-    # Profiles
-    pre = {imports = [inputs.cardano-parts.nixosModules.profile-pre-release];};
-
-    ram5gibActual = nixos: {
-      # The amount required for doing chain re-validation after a failed startup; less crashes
-      services.cardano-node.totalMaxHeapSizeMiB = 4096;
-      systemd.services.cardano-node.serviceConfig.MemoryMax = nixos.lib.mkForce "5G";
-    };
-
-    ram8gib = nixos: {
-      # On an 8 GiB machine, 7.5 GiB is reported as available in free -h
-      services.cardano-node.totalMaxHeapSizeMiB = 5734;
-      systemd.services.cardano-node.serviceConfig.MemoryMax = nixos.lib.mkForce "7G";
-    };
-
-    node821 = {
-      imports = [
-        (nixos: let
-          inherit (nixos.config.cardano-parts.perNode.lib.opsLib) mkCardanoLib;
-        in {
-          cardano-parts.perNode.lib.cardanoLib = mkCardanoLib "x86_64-linux" inputs.nixpkgs inputs.iohk-nix-legacy;
-          cardano-parts.perNode.pkgs = {
-            inherit (inputs.cardano-node-821-pre.packages.x86_64-linux) cardano-cli cardano-node cardano-submit-api;
-          };
-          services.cardano-node.publicProducers = [
-            {
-              accessPoints = [
-                {
-                  address = "backbone.cardano.iog.io";
-                  port = 3001;
-                }
-              ];
-              advertise = false;
-            }
-          ];
-        })
-      ];
-    };
-
-    nodeHd = {
-      imports = [
-        (nixos: let
-          inherit (nixos.config.cardano-parts.perNode.lib.opsLib) mkCardanoLib;
-        in {
-          cardano-parts.perNode.lib.cardanoLib = mkCardanoLib "x86_64-linux" inputs.nixpkgs inputs.iohk-nix-legacy;
-          cardano-parts.perNode.pkgs = {
-            inherit (inputs.cardano-node-hd.packages.x86_64-linux) cardano-cli cardano-node cardano-submit-api;
-          };
-          services.cardano-node.publicProducers = [
-            {
-              accessPoints = [
-                {
-                  address = "backbone.cardano.iog.io";
-                  port = 3001;
-                }
-              ];
-              advertise = false;
-            }
-          ];
-        })
-      ];
-    };
-
-    lmdb = {services.cardano-node.extraArgs = ["--lmdb-ledger-db-backend"];};
-
-    smash = {
-      imports = [
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-smash-service
-        inputs.cardano-parts.nixosModules.profile-cardano-smash
-        {services.cardano-smash.acmeEmail = "devops@iohk.io";}
-      ];
-    };
-
-    # Snapshots: add this to a dbsync machine defn and deploy; remove once the snapshot is restored.
-    # Snapshots for mainnet can be found at: https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.1/
-    # snapshot = {services.cardano-db-sync.restoreSnapshot = "$SNAPSHOT_URL";};
-
-    webserver = {
-      imports = [
-        inputs.cardano-parts.nixosModules.profile-cardano-webserver
-        {
-          services.cardano-webserver = {
-            acmeEmail = "devops@iohk.io";
-
-            # Always keep the book staging alias present so we aren't making frequent ACME cert requests
-            # when temporarily publishing a staging environment and then removing it shortly later.
-            serverAliases = ["book-staging.${domain}"];
-          };
-        }
-      ];
-    };
-
-    # Topology profiles
-    # Note: not including a topology profile will default to edge topology if module profile-cardano-node-group is imported
-    topoBp = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-node-topology = {role = "bp";};}];};
-    topoRel = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-node-topology = {role = "relay";};}];};
-
-    # Roles
-    bp = {imports = [inputs.cardano-parts.nixosModules.role-block-producer topoBp];};
-    rel = {imports = [inputs.cardano-parts.nixosModules.role-relay topoRel];};
-
-    dbsync = {
-      imports = [
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-db-sync-service
-        inputs.cardano-parts.nixosModules.profile-cardano-db-sync
-        inputs.cardano-parts.nixosModules.profile-cardano-node-group
-        inputs.cardano-parts.nixosModules.profile-cardano-postgres
-        {services.cardano-postgres.enablePsqlrc = true;}
-      ];
-    };
-
-    preprodSmash = {services.cardano-smash.serverAliases = lib.flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["preprod-smash" "preprod-explorer"]);};
-    previewSmash = {services.cardano-smash.serverAliases = lib.flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["preview-smash" "preview-explorer"]);};
-    privateSmash = {services.cardano-smash.serverAliases = lib.flatten (map (e: ["${e}.${domain}"]) ["private-smash" "private-explorer"]);};
-    sanchoSmash = {services.cardano-smash.serverAliases = lib.flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["sanchonet-smash" "sanchonet-explorer"]);};
-    shelleySmash = {services.cardano-smash.serverAliases = lib.flatten (map (e: ["${e}.${domain}"]) ["shelley-qa-smash" "shelley-qa-explorer"]);};
-
-    faucet = {
-      imports = [
-        # TODO: Module import fixup for local services
-        # config.flake.cardano-parts.cluster.groups.default.meta.cardano-faucet-service
-        inputs.cardano-parts.nixosModules.service-cardano-faucet
-
-        inputs.cardano-parts.nixosModules.profile-cardano-faucet
-        {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
-      ];
-    };
-
-    preprodFaucet = {services.cardano-faucet.serverAliases = ["faucet.preprod.${domain}" "faucet.preprod.world.dev.cardano.org"];};
-    previewFaucet = {services.cardano-faucet.serverAliases = ["faucet.preview.${domain}" "faucet.preview.world.dev.cardano.org"];};
-    privateFaucet = {services.cardano-faucet.serverAliases = ["faucet.private.${domain}"];};
-    sanchoFaucet = {services.cardano-faucet.serverAliases = ["faucet.sanchonet.${domain}" "faucet.sanchonet.world.dev.cardano.org"];};
-    shelleyFaucet = {services.cardano-faucet.serverAliases = ["faucet.shelley-qa.${domain}"];};
-
-    metadata = {
-      imports = [
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-metadata-service
-        inputs.cardano-parts.nixosModules.profile-cardano-metadata
-        inputs.cardano-parts.nixosModules.profile-cardano-postgres
-        {
-          services.cardano-metadata.acmeEmail = "devops@iohk.io";
-          services.cardano-metadata.serverAliases = ["metadata.${domain}" "metadata.world.dev.cardano.org"];
-        }
-      ];
-    };
-
-    mkWorldRelayMig = worldPort: {
-      networking.firewall = {
-        allowedTCPPorts = [worldPort];
-        extraCommands = "iptables -t nat -A PREROUTING -i ens5 -p tcp --dport ${toString worldPort} -j REDIRECT --to-port 3001";
-        extraStopCommands = "iptables -t nat -D PREROUTING -i ens5 -p tcp --dport ${toString worldPort} -j REDIRECT --to-port 3001 || true";
-      };
-    };
-
-    # Preprod to be applied once preprod pools finish their retirement forging epoch and a CNAME redirect is applied
-    preprodRelMig = mkWorldRelayMig 30000;
-    previewRelMig = mkWorldRelayMig 30002;
-    sanchoRelMig = mkWorldRelayMig 30004;
-
-    multiInst = {services.cardano-node.instances = 2;};
-    # # p2p and legacy network debugging code
-    # netDebug = {
-    #   services.cardano-node = {
-    #     useNewTopology = false;
-    #     extraNodeConfig = {
-    #       TraceMux = true;
-    #       TraceConnectionManagerTransitions = true;
-    #       DebugPeerSelectionInitiator = true;
-    #       DebugPeerSelectionInitiatorResponder = true;
-    #       options.mapSeverity = {
-    #         "cardano.node.ChainSyncProtocol" = "Error";
-    #         "cardano.node.ConnectionManager" = "Debug";
-    #         "cardano.node.ConnectionManagerTransition" = "Debug";
-    #         "cardano.node.DebugPeerSelection" = "Debug";
-    #         "cardano.node.Handshake" = "Debug";
-    #         "cardano.node.InboundGovernor" = "Debug";
-    #         "cardano.node.Mux" = "Info";
-    #         "cardano.node.PeerSelectionActions" = "Debug";
-    #         "cardano.node.PeerSelection" = "Info";
-    #         "cardano.node.resources" = "Notice";
-    #       };
-    #     };
-    #   };
-    # };
-    #
-    # # Disable p2p
-    # disableP2p = {
-    #   services.cardano-node = {
-    #     useNewTopology = false;
-    #     extraNodeConfig.EnableP2P = false;
-    #   };
-    # };
-    #
-    # # Allow legacy group incoming connections on bps if non-p2p testing is required
-    # mkBpLegacyFwRules = nodeNameList: {
-    #   networking.firewall = {
-    #     extraCommands = lib.concatMapStringsSep "\n" (n: "iptables -t filter -I nixos-fw -i ens5 -p tcp -m tcp -s ${n}.${domain} --dport 3001 -j nixos-fw-accept") nodeNameList;
-    #     extraStopCommands = lib.concatMapStringsSep "\n" (n: "iptables -t filter -D nixos-fw -i ens5 -p tcp -m tcp -s ${n}.${domain} --dport 3001 -j nixos-fw-accept || true") nodeNameList;
-    #   };
-    # };
-    #
-    # # Example add fw rules for relay to block producer connections in non-p2p network setup
-    # sancho1bpLegacy = mkBpLegacyFwRules ["sanchonet1-rel-a-1" "sanchonet1-rel-b-1" "sanchonet1-rel-c-1"];
-    # sancho2bpLegacy = mkBpLegacyFwRules ["sanchonet2-rel-a-1" "sanchonet2-rel-b-1" "sanchonet2-rel-c-1"];
-    # sancho3bpLegacy = mkBpLegacyFwRules ["sanchonet3-rel-a-1" "sanchonet3-rel-b-1" "sanchonet3-rel-c-1"];
-    #
-    # extraProd = producerList: {services.cardano-node-topology.extraNodeListProducers = producerList;};
-    #
-    # # A legacy machine will need to have at least partial peer mesh to other groups, example:
-    # sanchonet1-rel-a-1 = {imports = [ <...> disableP2p (extraProd ["sanchonet2-rel-a-1" "sanchonet3-rel-a-1"])];};
-  in {
-    meta = {
-      nixpkgs = import inputs.nixpkgs {
-        system = "x86_64-linux";
+        # Since all machines are assigned a group, this is a good place to include default aws instance tags
+        aws.instance.tags = {
+          inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
+          environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
+          group = name;
+        };
       };
 
-      nodeSpecialArgs =
-        lib.foldl'
-        (acc: node: let
-          instanceType = node: nixosConfigurations.${node}.config.aws.instance.instance_type;
-        in
-          lib.recursiveUpdate acc {
-            ${node} = {
-              nodeResources = {
-                inherit
-                  (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
-                  provider
-                  coreCount
-                  cpuCount
-                  memMiB
-                  nodeType
-                  threadsPerCore
-                  ;
-              };
+      # Cardano-node modules for group deployment
+      node = {
+        imports = [
+          # Base cardano-node service
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
+
+          # Config for cardano-node group deployments
+          inputs.cardano-parts.nixosModules.profile-cardano-node-group
+        ];
+      };
+
+      # Profiles
+      pre = {imports = [inputs.cardano-parts.nixosModules.profile-pre-release];};
+
+      ram5gibActual = nixos: {
+        # The amount required for doing chain re-validation after a failed startup; less crashes
+        services.cardano-node.totalMaxHeapSizeMiB = 4096;
+        systemd.services.cardano-node.serviceConfig.MemoryMax = nixos.lib.mkForce "5G";
+      };
+
+      ram8gib = nixos: {
+        # On an 8 GiB machine, 7.5 GiB is reported as available in free -h
+        services.cardano-node.totalMaxHeapSizeMiB = 5734;
+        systemd.services.cardano-node.serviceConfig.MemoryMax = nixos.lib.mkForce "7G";
+      };
+
+      node821 = {
+        imports = [
+          (nixos: let
+            inherit (nixos.config.cardano-parts.perNode.lib.opsLib) mkCardanoLib;
+          in {
+            cardano-parts.perNode.lib.cardanoLib = mkCardanoLib "x86_64-linux" inputs.nixpkgs inputs.iohk-nix-legacy;
+            cardano-parts.perNode.pkgs = {
+              inherit (inputs.cardano-node-821-pre.packages.x86_64-linux) cardano-cli cardano-node cardano-submit-api;
             };
+            services.cardano-node.publicProducers = [
+              {
+                accessPoints = [
+                  {
+                    address = "backbone.cardano.iog.io";
+                    port = 3001;
+                  }
+                ];
+                advertise = false;
+              }
+            ];
           })
-        {} (builtins.attrNames nixosConfigurations);
+        ];
+      };
+
+      nodeHd = {
+        imports = [
+          (nixos: let
+            inherit (nixos.config.cardano-parts.perNode.lib.opsLib) mkCardanoLib;
+          in {
+            cardano-parts.perNode.lib.cardanoLib = mkCardanoLib "x86_64-linux" inputs.nixpkgs inputs.iohk-nix-legacy;
+            cardano-parts.perNode.pkgs = {
+              inherit (inputs.cardano-node-hd.packages.x86_64-linux) cardano-cli cardano-node cardano-submit-api;
+            };
+            services.cardano-node.publicProducers = [
+              {
+                accessPoints = [
+                  {
+                    address = "backbone.cardano.iog.io";
+                    port = 3001;
+                  }
+                ];
+                advertise = false;
+              }
+            ];
+          })
+        ];
+      };
+
+      lmdb = {services.cardano-node.extraArgs = ["--lmdb-ledger-db-backend"];};
+
+      smash = {
+        imports = [
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-smash-service
+          inputs.cardano-parts.nixosModules.profile-cardano-smash
+          {services.cardano-smash.acmeEmail = "devops@iohk.io";}
+        ];
+      };
+
+      # Snapshots: add this to a dbsync machine defn and deploy; remove once the snapshot is restored.
+      # Snapshots for mainnet can be found at: https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.1/
+      # snapshot = {services.cardano-db-sync.restoreSnapshot = "$SNAPSHOT_URL";};
+
+      webserver = {
+        imports = [
+          inputs.cardano-parts.nixosModules.profile-cardano-webserver
+          {
+            services.cardano-webserver = {
+              acmeEmail = "devops@iohk.io";
+
+              # Always keep the book staging alias present so we aren't making frequent ACME cert requests
+              # when temporarily publishing a staging environment and then removing it shortly later.
+              serverAliases = ["book-staging.${domain}"];
+            };
+          }
+        ];
+      };
+
+      # Topology profiles
+      # Note: not including a topology profile will default to edge topology if module profile-cardano-node-group is imported
+      topoBp = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-node-topology = {role = "bp";};}];};
+      topoRel = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-node-topology = {role = "relay";};}];};
+
+      # Roles
+      bp = {imports = [inputs.cardano-parts.nixosModules.role-block-producer topoBp];};
+      rel = {imports = [inputs.cardano-parts.nixosModules.role-relay topoRel];};
+
+      dbsync = {
+        imports = [
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-db-sync-service
+          inputs.cardano-parts.nixosModules.profile-cardano-db-sync
+          inputs.cardano-parts.nixosModules.profile-cardano-node-group
+          inputs.cardano-parts.nixosModules.profile-cardano-postgres
+          {services.cardano-postgres.enablePsqlrc = true;}
+        ];
+      };
+
+      preprodSmash = {services.cardano-smash.serverAliases = flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["preprod-smash" "preprod-explorer"]);};
+      previewSmash = {services.cardano-smash.serverAliases = flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["preview-smash" "preview-explorer"]);};
+      privateSmash = {services.cardano-smash.serverAliases = flatten (map (e: ["${e}.${domain}"]) ["private-smash" "private-explorer"]);};
+      sanchoSmash = {services.cardano-smash.serverAliases = flatten (map (e: ["${e}.${domain}" "${e}.world.dev.cardano.org"]) ["sanchonet-smash" "sanchonet-explorer"]);};
+      shelleySmash = {services.cardano-smash.serverAliases = flatten (map (e: ["${e}.${domain}"]) ["shelley-qa-smash" "shelley-qa-explorer"]);};
+
+      faucet = {
+        imports = [
+          # TODO: Module import fixup for local services
+          # config.flake.cardano-parts.cluster.groups.default.meta.cardano-faucet-service
+          inputs.cardano-parts.nixosModules.service-cardano-faucet
+
+          inputs.cardano-parts.nixosModules.profile-cardano-faucet
+          {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
+        ];
+      };
+
+      preprodFaucet = {services.cardano-faucet.serverAliases = ["faucet.preprod.${domain}" "faucet.preprod.world.dev.cardano.org"];};
+      previewFaucet = {services.cardano-faucet.serverAliases = ["faucet.preview.${domain}" "faucet.preview.world.dev.cardano.org"];};
+      privateFaucet = {services.cardano-faucet.serverAliases = ["faucet.private.${domain}"];};
+      sanchoFaucet = {services.cardano-faucet.serverAliases = ["faucet.sanchonet.${domain}" "faucet.sanchonet.world.dev.cardano.org"];};
+      shelleyFaucet = {services.cardano-faucet.serverAliases = ["faucet.shelley-qa.${domain}"];};
+
+      metadata = {
+        imports = [
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-metadata-service
+          inputs.cardano-parts.nixosModules.profile-cardano-metadata
+          inputs.cardano-parts.nixosModules.profile-cardano-postgres
+          {
+            services.cardano-metadata.acmeEmail = "devops@iohk.io";
+            services.cardano-metadata.serverAliases = ["metadata.${domain}" "metadata.world.dev.cardano.org"];
+          }
+        ];
+      };
+
+      mkWorldRelayMig = worldPort: {
+        networking.firewall = {
+          allowedTCPPorts = [worldPort];
+          extraCommands = "iptables -t nat -A PREROUTING -i ens5 -p tcp --dport ${toString worldPort} -j REDIRECT --to-port 3001";
+          extraStopCommands = "iptables -t nat -D PREROUTING -i ens5 -p tcp --dport ${toString worldPort} -j REDIRECT --to-port 3001 || true";
+        };
+      };
+
+      # Preprod to be applied once preprod pools finish their retirement forging epoch and a CNAME redirect is applied
+      preprodRelMig = mkWorldRelayMig 30000;
+      previewRelMig = mkWorldRelayMig 30002;
+      sanchoRelMig = mkWorldRelayMig 30004;
+
+      multiInst = {services.cardano-node.instances = 2;};
+      # # p2p and legacy network debugging code
+      # netDebug = {
+      #   services.cardano-node = {
+      #     useNewTopology = false;
+      #     extraNodeConfig = {
+      #       TraceMux = true;
+      #       TraceConnectionManagerTransitions = true;
+      #       DebugPeerSelectionInitiator = true;
+      #       DebugPeerSelectionInitiatorResponder = true;
+      #       options.mapSeverity = {
+      #         "cardano.node.ChainSyncProtocol" = "Error";
+      #         "cardano.node.ConnectionManager" = "Debug";
+      #         "cardano.node.ConnectionManagerTransition" = "Debug";
+      #         "cardano.node.DebugPeerSelection" = "Debug";
+      #         "cardano.node.Handshake" = "Debug";
+      #         "cardano.node.InboundGovernor" = "Debug";
+      #         "cardano.node.Mux" = "Info";
+      #         "cardano.node.PeerSelectionActions" = "Debug";
+      #         "cardano.node.PeerSelection" = "Info";
+      #         "cardano.node.resources" = "Notice";
+      #       };
+      #     };
+      #   };
+      # };
+      #
+      # # Disable p2p
+      # disableP2p = {
+      #   services.cardano-node = {
+      #     useNewTopology = false;
+      #     extraNodeConfig.EnableP2P = false;
+      #   };
+      # };
+      #
+      # # Allow legacy group incoming connections on bps if non-p2p testing is required
+      # mkBpLegacyFwRules = nodeNameList: {
+      #   networking.firewall = {
+      #     extraCommands = concatMapStringsSep "\n" (n: "iptables -t filter -I nixos-fw -i ens5 -p tcp -m tcp -s ${n}.${domain} --dport 3001 -j nixos-fw-accept") nodeNameList;
+      #     extraStopCommands = concatMapStringsSep "\n" (n: "iptables -t filter -D nixos-fw -i ens5 -p tcp -m tcp -s ${n}.${domain} --dport 3001 -j nixos-fw-accept || true") nodeNameList;
+      #   };
+      # };
+      #
+      # # Example add fw rules for relay to block producer connections in non-p2p network setup
+      # sancho1bpLegacy = mkBpLegacyFwRules ["sanchonet1-rel-a-1" "sanchonet1-rel-b-1" "sanchonet1-rel-c-1"];
+      # sancho2bpLegacy = mkBpLegacyFwRules ["sanchonet2-rel-a-1" "sanchonet2-rel-b-1" "sanchonet2-rel-c-1"];
+      # sancho3bpLegacy = mkBpLegacyFwRules ["sanchonet3-rel-a-1" "sanchonet3-rel-b-1" "sanchonet3-rel-c-1"];
+      #
+      # extraProd = producerList: {services.cardano-node-topology.extraNodeListProducers = producerList;};
+      #
+      # # A legacy machine will need to have at least partial peer mesh to other groups, example:
+      # sanchonet1-rel-a-1 = {imports = [ <...> disableP2p (extraProd ["sanchonet2-rel-a-1" "sanchonet3-rel-a-1"])];};
+    in {
+      meta = {
+        nixpkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+        };
+
+        nodeSpecialArgs =
+          foldl'
+          (acc: node: let
+            instanceType = node: nixosConfigurations.${node}.config.aws.instance.instance_type;
+          in
+            recursiveUpdate acc {
+              ${node} = {
+                nodeResources = {
+                  inherit
+                    (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
+                    provider
+                    coreCount
+                    cpuCount
+                    memMiB
+                    nodeType
+                    threadsPerCore
+                    ;
+                };
+              };
+            })
+          {} (attrNames nixosConfigurations);
+      };
+
+      defaults.imports = [
+        inputs.cardano-parts.nixosModules.module-aws-ec2
+        inputs.cardano-parts.nixosModules.module-cardano-parts
+        inputs.cardano-parts.nixosModules.profile-basic
+        inputs.cardano-parts.nixosModules.profile-common
+        inputs.cardano-parts.nixosModules.profile-grafana-agent
+        nixosModules.common
+      ];
+
+      # Setup cardano-world networks:
+      # ---------------------------------------------------------------------------------------------------------
+      # Preprod, two-thirds on release tag, one-third on pre-release tag
+      preprod1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node bp pre];};
+      preprod1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+      preprod1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+      preprod1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
+      preprod1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preprod1") dbsync smash pre preprodSmash];};
+      preprod1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node faucet pre preprodFaucet];};
+
+      preprod2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node bp pre];};
+      preprod2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
+      preprod2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
+      preprod2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
+
+      preprod3-bp-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod3") node bp pre];};
+      preprod3-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
+      preprod3-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
+      preprod3-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Preview, one-third on release tag, two-thirds on pre-release tag
+      preview1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node bp pre];};
+      preview1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+      preview1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+      preview1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
+      preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 100) (group "preview1") dbsync smash pre previewSmash];};
+      preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre previewFaucet];};
+
+      preview2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview2") node bp pre];};
+      preview2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
+      preview2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
+      preview2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
+
+      preview3-bp-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview3") node bp pre];};
+      preview3-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
+      preview3-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
+      preview3-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Private, pre-release
+      private1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node bp];};
+      private1-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node rel];};
+      private1-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private1") node rel];};
+      private1-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private1") node rel];};
+      private1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "private1") dbsync smash privateSmash];};
+      private1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node faucet privateFaucet];};
+
+      private2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private2") node bp];};
+      private2-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private2") node rel];};
+      private2-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private2") node rel];};
+      private2-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private2") node rel];};
+
+      private3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private3") node bp];};
+      private3-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private3") node rel];};
+      private3-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private3") node rel];};
+      private3-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private3") node rel];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Sanchonet, pre-release
+      sanchonet1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "sanchonet1") node bp];};
+      sanchonet1-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
+      sanchonet1-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
+      sanchonet1-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
+      sanchonet1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet1") dbsync smash sanchoSmash];};
+      sanchonet1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "sanchonet1") node faucet sanchoFaucet];};
+      sanchonet1-test-a-1 = {imports = [eu-central-1 r5-xlarge (ebs 40) (group "sanchonet1") node multiInst];};
+
+      sanchonet2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "sanchonet2") node bp];};
+      sanchonet2-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
+      sanchonet2-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
+      sanchonet2-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
+
+      sanchonet3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "sanchonet3") node bp];};
+      sanchonet3-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
+      sanchonet3-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
+      sanchonet3-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Shelley-qa, pre-release
+      shelley-qa1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node bp];};
+      shelley-qa1-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
+      shelley-qa1-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
+      shelley-qa1-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
+      shelley-qa1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "shelley-qa1") dbsync smash shelleySmash];};
+      shelley-qa1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node faucet shelleyFaucet];};
+
+      shelley-qa2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa2") node bp];};
+      shelley-qa2-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
+      shelley-qa2-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
+      shelley-qa2-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
+
+      shelley-qa3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa3") node bp];};
+      shelley-qa3-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
+      shelley-qa3-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
+      shelley-qa3-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Mainnet
+      mainnet1-dbsync-a-1 = {imports = [eu-central-1 r5-2xlarge (ebs 1000) (group "mainnet1") dbsync pre];};
+      mainnet1-rel-a-1 = {imports = [eu-central-1 r5-large (ebs 300) (group "mainnet1") node];};
+      mainnet1-rel-a-2 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram5gibActual];};
+      mainnet1-rel-a-3 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram8gib];};
+      mainnet1-rel-a-4 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node node821 ram8gib];};
+      # ---------------------------------------------------------------------------------------------------------
+
+      # ---------------------------------------------------------------------------------------------------------
+      # Misc
+      misc1-metadata-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "misc1") metadata];};
+      misc1-webserver-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "misc1") webserver];};
+      # ---------------------------------------------------------------------------------------------------------
     };
-
-    defaults.imports = [
-      inputs.cardano-parts.nixosModules.module-aws-ec2
-      inputs.cardano-parts.nixosModules.module-cardano-parts
-      inputs.cardano-parts.nixosModules.profile-basic
-      inputs.cardano-parts.nixosModules.profile-common
-      inputs.cardano-parts.nixosModules.profile-grafana-agent
-      nixosModules.common
-    ];
-
-    # Setup cardano-world networks:
-    # ---------------------------------------------------------------------------------------------------------
-    # Preprod, two-thirds on release tag, one-third on pre-release tag
-    preprod1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node bp pre];};
-    preprod1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
-    preprod1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
-    preprod1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod1") node rel pre preprodRelMig];};
-    preprod1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preprod1") dbsync smash pre preprodSmash];};
-    preprod1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod1") node faucet pre preprodFaucet];};
-
-    preprod2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node bp pre];};
-    preprod2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
-    preprod2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
-    preprod2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod2") node rel pre preprodRelMig];};
-
-    preprod3-bp-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod3") node bp pre];};
-    preprod3-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
-    preprod3-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
-    preprod3-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preprod3") node rel pre preprodRelMig];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Preview, one-third on release tag, two-thirds on pre-release tag
-    preview1-bp-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node bp pre];};
-    preview1-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
-    preview1-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
-    preview1-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview1") node rel pre previewRelMig];};
-    preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 100) (group "preview1") dbsync smash pre previewSmash];};
-    preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre previewFaucet];};
-
-    preview2-bp-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview2") node bp pre];};
-    preview2-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
-    preview2-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
-    preview2-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview2") node rel pre previewRelMig];};
-
-    preview3-bp-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview3") node bp pre];};
-    preview3-rel-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
-    preview3-rel-b-1 = {imports = [eu-west-1 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
-    preview3-rel-c-1 = {imports = [us-east-2 t3a-medium (ebs 40) (group "preview3") node rel pre previewRelMig];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Private, pre-release
-    private1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node bp];};
-    private1-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node rel];};
-    private1-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private1") node rel];};
-    private1-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private1") node rel];};
-    private1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "private1") dbsync smash privateSmash];};
-    private1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private1") node faucet privateFaucet];};
-
-    private2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private2") node bp];};
-    private2-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private2") node rel];};
-    private2-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private2") node rel];};
-    private2-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private2") node rel];};
-
-    private3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private3") node bp];};
-    private3-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "private3") node rel];};
-    private3-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "private3") node rel];};
-    private3-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "private3") node rel];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Sanchonet, pre-release
-    sanchonet1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "sanchonet1") node bp];};
-    sanchonet1-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
-    sanchonet1-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
-    sanchonet1-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet1") node rel sanchoRelMig];};
-    sanchonet1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet1") dbsync smash sanchoSmash];};
-    sanchonet1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "sanchonet1") node faucet sanchoFaucet];};
-    sanchonet1-test-a-1 = {imports = [eu-central-1 r5-xlarge (ebs 40) (group "sanchonet1") node multiInst];};
-
-    sanchonet2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "sanchonet2") node bp];};
-    sanchonet2-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
-    sanchonet2-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
-    sanchonet2-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet2") node rel sanchoRelMig];};
-
-    sanchonet3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "sanchonet3") node bp];};
-    sanchonet3-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
-    sanchonet3-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
-    sanchonet3-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "sanchonet3") node rel sanchoRelMig];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Shelley-qa, pre-release
-    shelley-qa1-bp-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node bp];};
-    shelley-qa1-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
-    shelley-qa1-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
-    shelley-qa1-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa1") node rel];};
-    shelley-qa1-dbsync-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "shelley-qa1") dbsync smash shelleySmash];};
-    shelley-qa1-faucet-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa1") node faucet shelleyFaucet];};
-
-    shelley-qa2-bp-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa2") node bp];};
-    shelley-qa2-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
-    shelley-qa2-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
-    shelley-qa2-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa2") node rel];};
-
-    shelley-qa3-bp-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa3") node bp];};
-    shelley-qa3-rel-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
-    shelley-qa3-rel-b-1 = {imports = [eu-west-1 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
-    shelley-qa3-rel-c-1 = {imports = [us-east-2 t3a-micro (ebs 40) (group "shelley-qa3") node rel];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Mainnet
-    mainnet1-dbsync-a-1 = {imports = [eu-central-1 r5-2xlarge (ebs 1000) (group "mainnet1") dbsync pre];};
-    mainnet1-rel-a-1 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node ram8gib];};
-    mainnet1-rel-a-2 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram5gibActual];};
-    mainnet1-rel-a-3 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node nodeHd lmdb ram8gib];};
-    mainnet1-rel-a-4 = {imports = [eu-central-1 m5a-large (ebs 300) (group "mainnet1") node node821 ram8gib];};
-    # ---------------------------------------------------------------------------------------------------------
-
-    # ---------------------------------------------------------------------------------------------------------
-    # Misc
-    misc1-metadata-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "misc1") metadata];};
-    misc1-webserver-a-1 = {imports = [eu-central-1 t3a-micro (ebs 40) (group "misc1") webserver];};
-    # ---------------------------------------------------------------------------------------------------------
-  };
-}
+  }

--- a/flake/terraform/cluster.nix
+++ b/flake/terraform/cluster.nix
@@ -344,7 +344,6 @@ in {
                 User root
                 UserKnownHostsFile /dev/null
                 StrictHostKeyChecking no
-                IdentityFile .ssh_key
                 ServerAliveCountMax 2
                 ServerAliveInterval 60
 

--- a/flake/terraform/cluster.nix
+++ b/flake/terraform/cluster.nix
@@ -141,7 +141,8 @@ in {
                 root_block_device = {
                   inherit (node.aws.instance.root_block_device) volume_size;
                   volume_type = "gp3";
-                  iops = 3000;
+                  iops = node.aws.instance.root_block_device.iops or 3000;
+                  throughput = node.aws.instance.root_block_device.throughput or 125;
                   delete_on_termination = true;
                   tags = {Name = name;} // node.aws.instance.tags or {};
                 };

--- a/flake/terraform/cluster/route53.nix-import
+++ b/flake/terraform/cluster/route53.nix-import
@@ -48,4 +48,7 @@ in {
   cname_smash_private = mkResource {name = "private-smash.${domain}"; records = ["private1-dbsync-a-1.${domain}"];};
   cname_smash_sanchonet = mkResource {name = "sanchonet-smash.${domain}"; records = ["sanchonet1-dbsync-a-1.${domain}"];};
   cname_smash_shelley_qa = mkResource {name = "shelley-qa-smash.${domain}"; records = ["shelley-qa1-dbsync-a-1.${domain}"];};
+
+  # Govtool
+  cname_govtool_private = mkResource {name = "private-govtool.${domain}"; records = ["private1-dbsync-a-1.${domain}"];};
 }

--- a/flake/terraform/grafana/alerts/varnish.nix-import
+++ b/flake/terraform/grafana/alerts/varnish.nix-import
@@ -9,7 +9,8 @@
         description = "The Cache hit rate is {{ printf \"%.0f\" $value }} percent over the last 5 minutes on {{$labels.instance}}, which is below the threshold of 80 percent.";
         summary = "Cache is not answering a sufficient percentage of read requests.";
       };
-      expr = "increase(varnish_main_cache_hit[10m]) / (clamp_min((increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m])), 1)) * 100 < 80 and (increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m]) > 0)  and ((increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m])) > 100)\n";
+      # The webservers pipe all traffic through varnish and are subject to large amounts of spam requests making the cache rate intermittently low
+      expr = "increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) / (clamp_min((increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m])), 1)) * 100 < 80 and (increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m]) > 0)  and ((increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m])) > 100)\n";
       for = "10m";
       labels = {severity = "warning";};
     }

--- a/flake/terraform/grafana/dashboards/cardano-node-p2p.json
+++ b/flake/terraform/grafana/dashboards/cardano-node-p2p.json
@@ -108,7 +108,6 @@
           "expr": "cardano_node_metrics_connectionManager_duplexConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -199,7 +198,6 @@
           "expr": "cardano_node_metrics_peerSelection_hot{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -290,7 +288,6 @@
           "expr": "cardano_node_metrics_inboundGovernor_hot{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -381,7 +378,6 @@
           "expr": "cardano_node_metrics_connectionManager_unidirectionalConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -472,7 +468,6 @@
           "expr": "cardano_node_metrics_peerSelection_warm{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -563,7 +558,6 @@
           "expr": "cardano_node_metrics_inboundGovernor_warm{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -654,7 +648,6 @@
           "expr": "cardano_node_metrics_connectionManager_incomingConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -745,7 +738,6 @@
           "expr": "cardano_node_metrics_peerSelection_cold{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -836,7 +828,6 @@
           "expr": "rate(cardano_node_metrics_served_block_latest_count_int{environment=\"$environment\"}[1h])/rate(cardano_node_metrics_blockNum_int{environment=\"$environment\"}[1h])",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -927,7 +918,6 @@
           "expr": "cardano_node_metrics_connectionManager_outgoingConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1018,7 +1008,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfOne{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1111,7 +1100,6 @@
           "expr": "avg(quantile_over_time(0.5,cardano_node_metrics_blockfetchclient_blockdelay_s{environment=\"$environment\"}[15m]))",
           "interval": "",
           "legendFormat": "P50",
-          "queryType": "randomWalk",
           "refId": "A"
         },
         {
@@ -1120,7 +1108,6 @@
           "hide": false,
           "interval": "",
           "legendFormat": "P95",
-          "queryType": "randomWalk",
           "refId": "B"
         }
       ],
@@ -1211,7 +1198,6 @@
           "expr": "cardano_node_metrics_connectionManager_prunableConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1302,7 +1288,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfThree{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1393,7 +1378,6 @@
           "expr": "rate(cardano_node_metrics_blockfetchclient_lateblocks{environment=\"$environment\"}[1h])/rate(cardano_node_metrics_blockNum_int{environment=\"$environment\"}[1h])",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1484,7 +1468,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfFive{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],

--- a/flake/terraform/grafana/dashboards/cardano-node.json
+++ b/flake/terraform/grafana/dashboards/cardano-node.json
@@ -842,8 +842,7 @@
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_slotsMissedNum_int{environment=\"$environment\"}[1h]) * 3600",
           "interval": "",
-          "legendFormat": "{{environment}}",
-          "queryType": "randomWalk",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1183,7 +1182,6 @@
           "hide": false,
           "interval": "",
           "legendFormat": "15 min average",
-          "queryType": "randomWalk",
           "range": true,
           "refId": "A"
         },

--- a/perSystem/devShells/default.nix
+++ b/perSystem/devShells/default.nix
@@ -1,14 +1,27 @@
-{
+flake: {
   # Uncomment for node service debugging
   # flake.config.cardano-parts.pkgs.special.cardano-node-service = "${flake.inputs.cardano-node-service.outPath}/nix/nixos";
 
-  perSystem = {inputs', ...}: {
-    cardano-parts.shell.global.defaultShell = "ops";
-    cardano-parts.shell.global.extraPkgs = [inputs'.cardano-parts.packages.pre-push];
+  perSystem = {
+    inputs',
+    system,
+    ...
+  }: {
+    cardano-parts = {
+      shell.global = {
+        defaultShell = "ops";
+        extraPkgs = [inputs'.cardano-parts.packages.pre-push];
+      };
 
-    # Note that these package config assignments impact not only the devShell which utilize
-    # the defined cardano-parts pkgs, but also deployable cluster groups which also may utilize them.
-    # cardano-parts.pkgs.cardano-cli-ng = flake.inputs.cardano-cli-ng.packages.${system}."cardano-cli:exe:cardano-cli";
-    # cardano-parts.pkgs.cardano-node-ng = flake.inputs.cardano-node-ng.packages.${system}.cardano-node;
+      # Note that these package config assignments impact not only the devShell which utilize
+      # the defined cardano-parts pkgs, but also deployable cluster groups which also may utilize them.
+      #
+      # Temporarily set all node and cli packages to the 8.7.3 tag
+      pkgs = {
+        inherit (flake.inputs.cardano-node-ng.packages.${system}) cardano-cli cardano-node;
+        cardano-cli-ng = flake.inputs.cardano-node-ng.packages.${system}.cardano-cli;
+        cardano-node-ng = flake.inputs.cardano-node-ng.packages.${system}.cardano-node;
+      };
+    };
   };
 }

--- a/secrets/groups/private1/deploy/private1-dbsync-a-1-vva-be.json
+++ b/secrets/groups/private1/deploy/private1-dbsync-a-1-vva-be.json
@@ -1,0 +1,24 @@
+{
+	"data": "ENC[AES256_GCM,data:xM81u3AlRtfTeH13f9upQDJBVHMC1PRulzwL5G98p+D26pCEr/P53cWqI0VYJ1s/ei06VmFNEnTBjtIwx4MdfvVfYG/caEEloQxX4Af0eI3Rj0USvu05EhfHVj2h15zj6DPEPR0Uw2Bq8+EtE8LCaOaPTdNEN86QkOGQRU9A3ZwpFzuI9FTaHmujc4vrdYnbElHJnGflFnzeIop+HYmsj0b8UVXeRkla7cncQS8VPipJjcUC7/eTVoNo9heXGcVj+g59yutPzAgYDE/E/ziDfK34ualPCvvHxdxbFPgFMRwV559Ly5xnHdqMlHlaFRR2bI5lF767D4+ajz0f5HqMi5UD7XBAgUjtm/ENDt1UiNVvIsKKYKdG3DEcuOdHkfzw1Z90git1jMHBekrWhg==,iv:XACJ0OaCI25gZ8LevnHsYytERQyLbUn67hEAj8MXwFM=,tag:fu68qSrtX+Z0iRqXF1LtLw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1rj7vaq0rsarnum2fx6zq0k3l64f6mca9t9mlhqu4nfvpqhux6uts5zud2m",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4Vy9paTU0WHdzSTBqd3lT\nRHluOGo2VjYwRldUaEpaSzhwa3FzdTduUWtzClZINHdnbzZZT3pjZEdGQUZGN0dr\nVnczTC9VaTgyTFR2NTRFZTRlcStiRGsKLS0tIDhZTURGR1Y5Y3FJRDNwV0JOSHhn\nNzJqZXNEaEZOb1YyN2lwNlU4NTBqa0UKUb5ysZOcSJ6dCgd+r7OUV+gU01PuyOdd\nZFzVj9Gw61GuusRoI1ZxCBPYAMVjIrwgjNqaTGL3TwF3czL2XSpHdA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1q435aw99zpavtn5ce770jesh3th0ghne8jkt5mse8zscpp5r2ghsark64e",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXaXhhVngzQ25STDFXSmRL\nYjR6Z0NyRWxDMkxwRElmN0xuOW16MzhDbW1nCmxXbkE0RldIbXdhU3Q2UlRxYzFx\nYTZBZkdVL08xWWZnL0x4ZkJUQWl6QlUKLS0tIFU1cW5rMWNpemNQZkxTcEZuWFZO\nZzFDVi9iQm0rWkc4S0ZzeHRuT0ZwQ2MKB9ptHU3IHSON6MDmLiTkIgBDDV74MwH+\ngrh3Dty1oZLIyX/7XH2U5rq/ns8GuGsty/68EHsGzbATTQEu2LjBWA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2023-12-19T21:45:41Z",
+		"mac": "ENC[AES256_GCM,data:bh/4b45nI37AvvjXXCzJSVAUVc3VQ1XWu3nrY4TR1JvLetIztDmh62P3ne/sfo5HCXWDYj+xj+A0l4IHkm56X56ZSdVhqmnRX4t8dRnkGE1u9nOlikOcx2UUgG+IvtfvU7eyNhlsTu7yE5ZUDl0YyC7FImTO8lc0ppvT5jSnPHg=,iv:nwHIlA/885YVEeWJoMACMe+r9Odst33PdB1TmRe2Fm4=,tag:UDfQjwEU+SEGrg0bHliBTg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}


### PR DESCRIPTION
# Overview:
Add a voltaire govtool backend swagger UI for private chain, misc fixes and updates

# Details:
* Add a voltaire govtool backend swagger UI for private chain use
* Update inputs for the IntersectMBO migration
* Fix bootstrap key use in the default ssh config for those not using an SSH/GPG agent
* Fix tofu create-all prompt on pre-existing resources
