### PR TITLE
Update to valency in topology files

### DIFF
--- a/docs/environments/mainnet/topology-non-bootstrap-peers.json
+++ b/docs/environments/mainnet/topology-non-bootstrap-peers.json
@@ -3,7 +3,7 @@
     {
       "accessPoints": [],
       "advertise": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/mainnet/topology.json
+++ b/docs/environments/mainnet/topology.json
@@ -18,7 +18,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/preprod/topology.json
+++ b/docs/environments/preprod/topology.json
@@ -10,7 +10,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/preview/topology.json
+++ b/docs/environments/preview/topology.json
@@ -10,7 +10,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/private/topology.json
+++ b/docs/environments/private/topology.json
@@ -10,7 +10,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/sanchonet/topology.json
+++ b/docs/environments/sanchonet/topology.json
@@ -10,7 +10,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [

--- a/docs/environments/shelley-qa/topology.json
+++ b/docs/environments/shelley-qa/topology.json
@@ -10,7 +10,7 @@
       "accessPoints": [],
       "advertise": false,
       "trustable": false,
-      "valency": 1
+      "valency": <number of items in accessPoints>
     }
   ],
   "publicRoots": [


### PR DESCRIPTION
All the topology examples show a valency of 1, but a lot of SPOs forget to update this value to the number of items in the accessPoints array when adding access points to it (there might be circumstances where you would use another value, but in most cases it'll be equal to the number of access points, not taking into account the case where the domain resolves to multiple ip addresses).

Current JSON is not valid because of the place holder, but I think getting an error message because of this is better than forgetting to change the 1 value.