### PR TITLE
Group block delay/utilization alerts by environment and instance

### DIFF
--- a/flake/opentofu/grafana/alerts/cardano-node-network.nix-import
+++ b/flake/opentofu/grafana/alerts/cardano-node-network.nix-import
@@ -17,44 +17,44 @@ in {
     }
     {
       alert = "blocks_adoption_delay_too_high";
-      expr = "avg(quantile_over_time(0.95, cardano_node_metrics_blockadoption_forgeDelay_real[6h])) >= 4.5";
+      expr = "avg by (environment, instance) (quantile_over_time(0.95, cardano_node_metrics_blockadoption_forgeDelay_real[6h])) >= 4.5";
       for = "1m";
       labels.severity = "page";
       annotations = {
-        summary = "Blocks adoption delay has been above 4.5s for more than 5% of blocks.";
-        description = "Node average of blocks adoption delay has been above 4.5s for more than 5% of blocks for more than 6 hours.";
+        summary = "{{$labels.environment}}/{{$labels.instance}}: block adoption delay above 4.5s for more than 5% of blocks.";
+        description = "{{$labels.environment}}/{{$labels.instance}}: block adoption delay has been above 4.5s for more than 5% of blocks over the last 6 hours.";
       };
     }
     {
       alert = "blocks_adoption_delay_too_high_new_tracing";
-      expr = "avg(quantile_over_time(0.95, cardano_node_metrics_blockfetchclient_blockdelay_real[6h])) >= 4.5";
+      expr = "avg by (environment, instance) (quantile_over_time(0.95, cardano_node_metrics_blockfetchclient_blockdelay_real[6h])) >= 4.5";
       for = "1m";
       labels.severity = "page";
       annotations = {
-        summary = "Blocks adoption delay has been above 4.5s for more than 5% of blocks.";
-        description = "Node average of blocks adoption delay has been above 4.5s for more than 5% of blocks for more than 6 hours.";
+        summary = "{{$labels.environment}}/{{$labels.instance}}: block adoption delay above 4.5s for more than 5% of blocks.";
+        description = "{{$labels.environment}}/{{$labels.instance}}: block adoption delay has been above 4.5s for more than 5% of blocks over the last 6 hours.";
       };
     }
     # TODO: Static max block size until node publishes max block size metric
     {
       alert = "blocks_utilization_too_high";
-      expr = "100 * avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize[6h]) / 90112) > ${highBlockUtilization}";
+      expr = "100 * avg by (environment, instance) (avg_over_time(cardano_node_metrics_blockfetchclient_blocksize[6h]) / 90112) > ${highBlockUtilization}";
       for = "5m";
       labels.severity = "page";
       annotations = {
-        summary = "Block utilization is above ${highBlockUtilization}%.";
-        description = "Block utilization has averaged above ${highBlockUtilization}% for more than 6h.";
+        summary = "{{$labels.environment}}/{{$labels.instance}}: block utilization is above ${highBlockUtilization}%.";
+        description = "{{$labels.environment}}/{{$labels.instance}}: block utilization has averaged above ${highBlockUtilization}% over the last 6h.";
       };
     }
     # TODO: Static max block size until node publishes max block size metric
     {
       alert = "blocks_utilization_too_high_new_tracing";
-      expr = "100 * avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize_int[6h]) / 90112) > ${highBlockUtilization}";
+      expr = "100 * avg by (environment, instance) (avg_over_time(cardano_node_metrics_blockfetchclient_blocksize_int[6h]) / 90112) > ${highBlockUtilization}";
       for = "5m";
       labels.severity = "page";
       annotations = {
-        summary = "Block utilization is above ${highBlockUtilization}%.";
-        description = "Block utilization has averaged above ${highBlockUtilization}% for more than 6h.";
+        summary = "{{$labels.environment}}/{{$labels.instance}}: block utilization is above ${highBlockUtilization}%.";
+        description = "{{$labels.environment}}/{{$labels.instance}}: block utilization has averaged above ${highBlockUtilization}% over the last 6h.";
       };
     }
     {


### PR DESCRIPTION
## Overview

The four block-adoption-delay and block-utilization alerts in `cardano-node-network.nix-import` wrapped a bare `avg()` that collapsed every environment and instance into a single scalar. As a result a page carried no label or annotation identifying the affected node, and a misbehaving node could be masked by being averaged in with healthy ones. This change groups each alert by `(environment, instance)` so they evaluate per node, and templates the offending node into the alert summary and description.

## Key Changes

* Change `avg()` to `avg by (environment, instance)` in `blocks_adoption_delay_too_high`, `blocks_adoption_delay_too_high_new_tracing`, `blocks_utilization_too_high`, and `blocks_utilization_too_high_new_tracing` so each alert evaluates per node rather than as one cluster-wide scalar.
* Template `{{$labels.environment}}/{{$labels.instance}}` into each alert's summary and description so a page identifies the culprit node.
